### PR TITLE
Add lenny and maverick to the list of debian dists

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ end
 
 @debversion = ENV["debversion"] ||= "1.0"
 @release = ENV["release"] ||= "5"
-@deb_dists = ["hardy", "lucid", "natty", "oneiric", "precise", "sid", "squeeze", "unstable", "wheezy", "stable"]
+@deb_dists = ["hardy", "lenny", "lucid", "maverick", "natty", "oneiric", "precise", "sid", "squeeze", "unstable", "wheezy", "stable"]
 @signwith = ENV["signwith"] ||= "4BD6EC30"
 @nosign ||= ENV["no_sign"]
 @signmacros = %{--define "%_gpg_name #{@signwith}"}


### PR DESCRIPTION
Even though these releases are EOL, we still have them on apt.puppetlabs.com,
so we should build release packages for them until we decide to remove them
entirely.
