### PR TITLE
(maint) Swap mock arches and copy from x86_64 to i386

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,17 @@ def build_rpm(dist)
   mock = "#{@dist == 'el' ? 'pl-el' : 'pl-fedora'}-#{@version}-x86_64"
   sh "mock -r #{mock} #{base}/SRPMS/#{@name}-#{@version}-#{@release}.src.rpm"
 
-  cp_pr "/var/lib/mock/#{mock}/result/#{@name}-#{@version}-#{@release}.noarch.rpm", "#{base}/i386/"
+
+
+  # Is this wrapped in an unless? Yes it is.
+  # Why isn't #unless at the end of the command? because it's a very long line.
+  # Why are we doing this? Because RHEL7 i386 doesn't exist yet and
+  # populating this will just make an empty repo. We'll have to back this
+  # out when CentOS drops a 32-bit EL7 release but in the mean time, kludge.
+  unless @dist == 'el' && @version == '7'
+    cp_pr "/var/lib/mock/#{mock}/result/#{@name}-#{@version}-#{@release}.noarch.rpm", "#{base}/i386/"
+  end
+
   cp_pr "/var/lib/mock/#{mock}/result/#{@name}-#{@version}-#{@release}.noarch.rpm", "#{base}/x86_64/"
   ln_sf "#{base}/i386/#{@name}-#{@version}-#{@release}.noarch.rpm", "#{topdir}/#{@name}-#{@dist}-#{@version}.noarch.rpm"
 end


### PR DESCRIPTION
Since this package is inherently noarch, we used to build it in an i386 mock instead of a x86_64 one. With RHEL7 likely to go 64-bit only, this commit swaps the mock arch and copies the resultant artifact correctly.
