### PR TITLE
(RE-4059) Update puppetlabs-release-pc1 to enable shipping 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,38 @@
+RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
+
+begin
+  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
+rescue LoadError
+end
+
+build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
+if File.exist?(build_defs_file)
+  begin
+    require 'yaml'
+    @build_defaults ||= YAML.load_file(build_defs_file)
+  rescue Exception => e
+    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
+    raise e
+  end
+  @packaging_url  = @build_defaults['packaging_url']
+  @packaging_repo = @build_defaults['packaging_repo']
+  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
+  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
+
+  namespace :package do
+ #   desc "Bootstrap packaging automation, e.g. clone into packaging repo"
+    task :bootstrap do
+      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
+        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
+      else
+        cd File.join(RAKE_ROOT, 'ext') do
+          %x{git clone #{@packaging_url}}
+        end
+      end
+    end
+ #   desc "Remove all cloned packaging automation"
+    task :implode do
+      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
+    end
+  end
+end

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -4,6 +4,7 @@ project 'puppetlabs-release-pc1' do |proj|
   proj.version '1.2.3'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'
   proj.homepage 'https://www.puppetlabs.com'
+  proj.target_repo 'PC1'
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,7 +1,7 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
   proj.license 'ASL 2.0'
-  proj.version '1.2.3'
+  proj.version_from_git
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'
   proj.homepage 'https://www.puppetlabs.com'
   proj.target_repo 'PC1'

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,10 @@
+---
+project: 'puppetlabs-release-pc1'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_repo: 'packaging'
+gpg_name: 'info@puppetlabs.com'
+gpg_key: '4BD6EC30'
+sign_tar: FALSE
+vanagon_project: TRUE
+apt_repo_name: 'PC1'
+yum_repo_name: 'PC1'

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,0 +1,1 @@
+build_defaults.yaml


### PR DESCRIPTION
In order to actually ship the release package, PC1 must be added to the
project config, and a build_defaults.yaml file is needed with PC1 set
for the apt and yum repo_name. A rakefile is also required to access
some of the packaging tasks not yet available via vanagon.