### PR TITLE
(RE-4059) Set build_tar to false in build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -8,3 +8,4 @@ sign_tar: FALSE
 vanagon_project: TRUE
 apt_repo_name: 'PC1'
 yum_repo_name: 'PC1'
+build_tar: FALSE


### PR DESCRIPTION
Without this setting, packaging will look for a tarball when
uber_shipping, which will fail. This commit adds the setting so that
shipping can happen.