### PR TITLE
(RE-4375) Set noarch to true for the release package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'vanagon', '~> 0.1', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
+gem 'vanagon', '~> 0.2', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -5,6 +5,7 @@ project 'puppetlabs-release-pc1' do |proj|
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'
   proj.homepage 'https://www.puppetlabs.com'
   proj.target_repo 'PC1'
+  proj.noarch
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'


### PR DESCRIPTION
There is nothing architecture specific about this release package, it is
only vanagon that was limiting this ability. This commit adds the noarch
declaration to the project config and moves the gem dependency forward
to pick up the vanagon feature required to support this.