### PR TITLE
(maint) This was the wrong place to store this data

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -7,9 +7,3 @@ gpg_key: '4BD6EC30'
 build_tar: FALSE
 sign_tar: FALSE
 vanagon_project: TRUE
-apt_host: 'pl-build-tools.delivery.puppetlabs.net'
-apt_repo_path: '/opt/build-tools/debian'
-apt_repo_name: ''
-yum_host: 'pl-build-tools.delivery.puppetlabs.net'
-yum_repo_path: '/opt/build-tools/yum'
-yum_repo_name: ''


### PR DESCRIPTION
This data has been migrated to the build-data repo, to contend with
having to overwrite defaults set in the release team build-data settings