### PR TITLE
(maint) Bump vanagon version to 0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'vanagon', '~> 0.2', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
+gem 'vanagon', '~> 0.3', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'


### PR DESCRIPTION
This updates the version of vanagon to 0.3 providing additional platform support. 
Per @haus comments in #25 