### PR TITLE
(maint) Comment out the source repo

### DIFF
--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -3,7 +3,7 @@ component 'repo_definition' do |pkg, settings, platform|
 
   if platform.is_deb?
     pkg.url 'file://files/puppetlabs.list.txt'
-    pkg.md5sum 'f6fea0cbba6cdc10d904ea17572335b7'
+    pkg.md5sum '53d2e1455bab67b4a49a5d0969ebbb95'
     pkg.install_file 'puppetlabs.list.txt', '/etc/apt/sources.list.d/puppetlabs-pc1.list'
     pkg.install do
       "sed -i 's|__CODENAME__|#{platform.codename}|g' /etc/apt/sources.list.d/puppetlabs-pc1.list"

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,7 +1,7 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
   proj.license 'ASL 2.0'
-  proj.version_from_git
+  proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'
   proj.homepage 'https://www.puppetlabs.com'
   proj.target_repo 'PC1'

--- a/files/puppetlabs.list.txt
+++ b/files/puppetlabs.list.txt
@@ -1,3 +1,9 @@
 # Puppetlabs PC1 __CODENAME__ Repository
 deb http://apt.puppetlabs.com __CODENAME__ PC1
-deb-src http://apt.puppetlabs.com __CODENAME__ PC1
+
+# Puppetlabs PC1 __CODENAME__ Source Repository
+# The source repos are commented out by default because we
+# do not always make sources available for all packages or
+# for all platforms. If you want to access the source repos,
+# uncomment the following line.
+#deb-src http://apt.puppetlabs.com __CODENAME__ PC1


### PR DESCRIPTION
We are not shipping source packages yet for our puppet-agent releases.
As a result, running 'apt-get update' on a system where only
puppet-agent packages are available in the puppeltabs repo returns an
error. It's looking for the source repo, which isn't there. Since the
majority of new repos that we create do not yet have any sources, and
will not until puppetdb or puppetserver are shipped to them, we need to
deliver the repos with the source repo disabled.

If a user wants to access the source repos, all they have to do is
uncomment the line in the puppetlabs.list file provided by the release
package.