### PR TITLE
(CPR-210) Allow puppetlabs-release-pc1 to not conflict with original

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'vanagon', '~> 0.3', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'
+gem 'json'
+gem 'rake'

--- a/configs/components/gpg_key.rb
+++ b/configs/components/gpg_key.rb
@@ -8,6 +8,6 @@ component 'gpg_key' do |pkg, settings, platform|
   else
     pkg.url 'file://files/RPM-GPG-KEY-puppetlabs.gpg'
     pkg.md5sum '339014f9b0517552c232501438f40b3d'
-    pkg.install_file 'RPM-GPG-KEY-puppetlabs.gpg', '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs'
+    pkg.install_file 'RPM-GPG-KEY-puppetlabs.gpg', '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1'
   end
 end

--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -1,5 +1,5 @@
 component 'repo_definition' do |pkg, settings, platform|
-  pkg.version '2015.03.31'
+  pkg.version '2015.09.28'
 
   if platform.is_deb?
     pkg.url 'file://files/puppetlabs.list.txt'
@@ -18,7 +18,7 @@ component 'repo_definition' do |pkg, settings, platform|
     end
 
     pkg.url 'file://files/puppetlabs.repo.txt'
-    pkg.md5sum '5f6c6e6f16bd22b11d15817b9df5cb19'
+    pkg.md5sum 'c5b79dc2f8a13d710a17e5f3ca502376'
     pkg.install_file 'puppetlabs.repo.txt', "#{repo_path}/puppetlabs-pc1.repo"
     pkg.install do
       "sed -i -e 's|__OS_NAME__|#{platform.os_name}|g' -e 's|__OS_VERSION__|#{platform.os_version}|g' #{repo_path}/puppetlabs-pc1.repo"

--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -4,7 +4,7 @@ component 'repo_definition' do |pkg, settings, platform|
   if platform.is_deb?
     pkg.url 'file://files/puppetlabs.list.txt'
     pkg.md5sum '53d2e1455bab67b4a49a5d0969ebbb95'
-    pkg.install_file 'puppetlabs.list.txt', '/etc/apt/sources.list.d/puppetlabs-pc1.list'
+    pkg.install_configfile 'puppetlabs.list.txt', '/etc/apt/sources.list.d/puppetlabs-pc1.list'
     pkg.install do
       "sed -i 's|__CODENAME__|#{platform.codename}|g' /etc/apt/sources.list.d/puppetlabs-pc1.list"
     end
@@ -19,7 +19,7 @@ component 'repo_definition' do |pkg, settings, platform|
 
     pkg.url 'file://files/puppetlabs.repo.txt'
     pkg.md5sum 'c5b79dc2f8a13d710a17e5f3ca502376'
-    pkg.install_file 'puppetlabs.repo.txt', "#{repo_path}/puppetlabs-pc1.repo"
+    pkg.install_configfile 'puppetlabs.repo.txt', "#{repo_path}/puppetlabs-pc1.repo"
     pkg.install do
       "sed -i -e 's|__OS_NAME__|#{platform.os_name}|g' -e 's|__OS_VERSION__|#{platform.os_version}|g' #{repo_path}/puppetlabs-pc1.repo"
     end

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,5 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
+  proj.release '2'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,6 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
-  proj.release '2'
+  proj.release '1'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/files/puppetlabs.repo.txt
+++ b/files/puppetlabs.repo.txt
@@ -1,14 +1,14 @@
 [puppetlabs-pc1]
 name=Puppet Labs PC1 Repository __OS_NAME__ __OS_VERSION__ - $basearch
 baseurl=http://yum.puppetlabs.com/__OS_NAME__/__OS_VERSION__/PC1/$basearch
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1
 enabled=1
 gpgcheck=1
 
 [puppetlabs-pc1-source]
 name=Puppet Labs PC1 Repository __OS_NAME__ __OS_VERSION__ - Source
 baseurl=http://yum.puppetlabs.com/__OS_NAME__/__OS_VERSION__/PC1/SRPMS
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1
 failovermethod=priority
 enabled=0
 gpgcheck=1


### PR DESCRIPTION
Prior to this commit, we unintentionally had the puppetlabs-relelase-pc1
conflict with puppetlabs-release, which is causing heartburn for some
folks. This fix simply changes the filename for the GPG key once
installed to include a -PC1 suffix.

The behavior now mimics the behavior on Debian, as in both release
packages can be installed.