### PR TITLE
(maint) Add VANAGON_LOCATION to pl-build-tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,16 @@
 source 'https://rubygems.org'
 
-gem 'vanagon', '~> 0.2', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
+def vanagon_location_for(place)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [{ :git => $1, :branch => $2, :require => false }]
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  elsif place =~ /(\d+\.\d+\.\d+)/
+    [$1, {:git => 'git@github.com:puppetlabs/vanagon', :tag => $1}]
+  end
+end
+
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'
 gem 'json'
 gem 'rake'

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ The puppetlabs-release repo is where all the automation lives to build release p
 ### Runtime Requirements
 The Gemfile specifies all of the needed ruby libraries to build a puppet-agent package. Additionally, the automation requires a VM to build within for each desired package.
 
+#### Environment variables
+##### VANAGON\_LOCATION
+The location of Vanagon in the Gemfile can be overridden with the environment variable `VANAGON_LOCATION`. Can be set prior to `bundle install` or updated with `bundle update`.
+
+* `0.3.14` - Specific tag from the Vanagon git repo
+* `git@github.com:puppetlabs/vanagon#master` - Remote git location and tag
+* `file:///workspace/vanagon` - Absolute file path
+* `file://../vanagon` - File path relative to the project directory
+
 ### Building pl-build-tools-release packages
 * `bundle install ;bundle exec build pl-build-tools-release ubuntu-14.04-amd64`
 


### PR DESCRIPTION
Prior to this commit the user was unable to override the location and version of Vanagon.  This is the same behaviour we have in puppet-agent and pl-build-tools vanagon