### PR TITLE
(maint) Add VANAGON_LOCATION to PC1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,16 @@
 source 'https://rubygems.org'
 
-gem 'vanagon', '~> 0.3', :git => 'git@github.com:puppetlabs/vanagon', :branch => 'master'
+def vanagon_location_for(place)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [{ :git => $1, :branch => $2, :require => false }]
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  elsif place =~ /(\d+\.\d+\.\d+)/
+    [$1, {:git => 'git@github.com:puppetlabs/vanagon', :tag => $1}]
+  end
+end
+
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')
 gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'
 gem 'json'
 gem 'rake'


### PR DESCRIPTION
Prior to this commit the user was unable to override the location and version of Vanagon.  This is the same behaviour we have in puppet-agent and pl-build-tools vanagon