### PR TITLE
(RE-6253) Add Fedora 23 to release definitions for build tools

### DIFF
--- a/configs/platforms/fedora-f23-i386.rb
+++ b/configs/platforms/fedora-f23-i386.rb
@@ -1,0 +1,9 @@
+platform "fedora-f23-i386" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y"
+  plat.vmpooler_template "fedora-23-i386"
+end

--- a/configs/platforms/fedora-f23-x86_64.rb
+++ b/configs/platforms/fedora-f23-x86_64.rb
@@ -1,0 +1,9 @@
+platform "fedora-f23-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "/usr/bin/dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y"
+  plat.vmpooler_template "fedora-23-x86_64"
+end


### PR DESCRIPTION
This adds Fedora 23.  It requires Vanagon >= 0.5.0 + dada8190fa6bd05bc1b2719c4046ecc792e55dca  

Latest master is now installed by default :)