### PR TITLE
(maint) Fix up DNF calls

### DIFF
--- a/configs/platforms/fedora-f22-i386.rb
+++ b/configs/platforms/fedora-f22-i386.rb
@@ -3,7 +3,7 @@ platform "fedora-f22-i386" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.provision_with "/usr/bin/dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
-  plat.install_build_dependencies_with "/usr/bin/dnf install -y"
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing "
   plat.vmpooler_template "fedora-22-i386"
 end

--- a/configs/platforms/fedora-f22-x86_64.rb
+++ b/configs/platforms/fedora-f22-x86_64.rb
@@ -3,7 +3,7 @@ platform "fedora-f22-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.provision_with "/usr/bin/dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
-  plat.install_build_dependencies_with "/usr/bin/dnf install -y"
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
   plat.vmpooler_template "fedora-22-x86_64"
 end

--- a/configs/platforms/fedora-f23-i386.rb
+++ b/configs/platforms/fedora-f23-i386.rb
@@ -3,7 +3,7 @@ platform "fedora-f23-i386" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.provision_with "/usr/bin/dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
-  plat.install_build_dependencies_with "/usr/bin/dnf install -y"
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
   plat.vmpooler_template "fedora-23-i386"
 end

--- a/configs/platforms/fedora-f23-x86_64.rb
+++ b/configs/platforms/fedora-f23-x86_64.rb
@@ -3,7 +3,7 @@ platform "fedora-f23-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.provision_with "/usr/bin/dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
-  plat.install_build_dependencies_with "/usr/bin/dnf install -y"
+  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
   plat.vmpooler_template "fedora-23-x86_64"
 end


### PR DESCRIPTION
In the Fedora OSes that default to DNF, --best --allowerasing should be
there. If they are not, you can end up in situations where some packages
upgrade, but then dnf bails due to an impossible transaction.