### PR TITLE
New Platforms for puppet-agent 1.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ def vanagon_location_for(place)
 end
 
 gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')
-gem 'packaging', '0.4.2', :github => 'puppetlabs/packaging', :tag => '0.4.2'
+gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'json'
 gem 'rake'

--- a/configs/platforms/cisco-wrlinux-7-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-7-x86_64.rb
@@ -1,0 +1,10 @@
+platform "cisco-wrlinux-7-x86_64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+  # The development environment provided by Cisco includes the build dependencies
+  # such as autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils
+  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/cisco-wrlinux/7/pl-build-tools-cisco-wrlinux-7.repo"
+  plat.install_build_dependencies_with "yum install -y"
+  plat.vmpooler_template "cisco-wrlinux-7-x86_64"
+end

--- a/configs/platforms/ubuntu-15.10-amd64.rb
+++ b/configs/platforms/ubuntu-15.10-amd64.rb
@@ -1,0 +1,10 @@
+platform "ubuntu-15.10-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "wily"
+  
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1510-x86_64"
+end

--- a/configs/platforms/ubuntu-15.10-i386.rb
+++ b/configs/platforms/ubuntu-15.10-i386.rb
@@ -1,0 +1,10 @@
+platform "ubuntu-15.10-i386" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "wily"
+  
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1510-i386"
+end


### PR DESCRIPTION
As part of the puppet-agent 1.3.4 release Ubuntu 15.10 and cisco-wrlinux-7 were added.  This PR includes commits for both of those platforms, as well as enables the latest version of the packaging repo to be used for shipping.