### PR TITLE
(RE-6775) 2016 Spring Cleaning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,62 @@
+AllCops:
+  TargetRubyVersion: 2.0
+  Exclude:
+    - 'files/**/*'
+    - 'templates/**/*'
+
+# ruby style guide favorite
+Style/StringLiterals:
+    EnforcedStyle: double_quotes
+
+# consistency with above
+Style/StringLiteralsInInterpolation:
+    EnforcedStyle: double_quotes
+
+# percent-x is allowed for multiline
+Style/CommandLiteral:
+    EnforcedStyle: mixed
+
+# paths abound, easy escape
+Style/RegexpLiteral:
+    EnforcedStyle: slashes
+
+# no metrics for this dumb Rakefile
+Metrics/AbcSize:
+    Enabled: false
+Metrics/CyclomaticComplexity:
+    Enabled: false
+Metrics/MethodLength:
+    Enabled: false
+Metrics/ClassLength:
+    Enabled: false
+Metrics/PerceivedComplexity:
+    Enabled: false
+
+# we often need very long lines
+Metrics/LineLength:
+    Enabled: false
+
+Style/Documentation:
+    Enabled: false
+
+# consistency and readability when faced with string interpolation
+Style/PercentLiteralDelimiters:
+    PreferredDelimiters:
+        '%':  '()'
+        '%i': '()'
+        '%q': '()'
+        '%Q': '()'
+        '%r': '{}'
+        '%s': '()'
+        '%w': '[]'
+        '%W': '[]'
+        '%x': '()'
+
+Style/UnneededCapitalW:
+    Enabled: false
+
+# we prefer compact if-else-end/case-when-end alignment
+Lint/EndAlignment:
+  AlignWith: variable
+Style/CaseIndentation:
+  IndentWhenRelativeTo: end

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 
 require "English"
 require "erb"
-require 'tmpdir'
+require "tmpdir"
 
 @name = "puppetlabs-release"
 @debversion = ENV["debversion"] ||= "1.0"
@@ -12,8 +12,8 @@ require 'tmpdir'
 @nosign ||= ENV["no_sign"]
 @signmacros = %(--define "%_gpg_name #{@signwith}")
 @signmacros_el5 = %(--define "%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha1 --batch --no-verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}")
-@rpm_rsync_url = ENV["rpm_rsync_url"] ||= "#{ENV["USER"]}@yum.puppetlabs.com:/opt/repository/yum"
-@deb_rsync_url = ENV["deb_rsync_url"] ||= "#{ENV["USER"]}@apt.puppetlabs.com:/opt/repository/incoming"
+@rpm_rsync_url = ENV["rpm_rsync_url"] ||= "#{ENV["USER"]}@weth.delivery.puppetlabs.net:/opt/repository/yum"
+@deb_rsync_url = ENV["deb_rsync_url"] ||= "#{ENV["USER"]}@weth.delivery.puppetlabs.net:/opt/tools/freight/apt"
 
 @matrix = {
   el5: { dist: "el", codename: "5", version: "5" },
@@ -186,7 +186,21 @@ namespace :rpm do
 
   desc "Ship the packages to the world"
   task ship: [:check] do
-    sh "rsync -avg pkg/rpm/* #{@rpm_rsync_url}"
+    cmd = %W[
+      rsync
+      --recursive
+      --hard-links
+      --links
+      --verbose
+      --omit-dir-times
+      --no-perms
+      --no-owner
+      --no-group
+      pkg/rpm/*
+      #{@rpm_rsync_url}
+    ].join(" ")
+
+    sh cmd
   end
 
   desc "Check the RPM signatures"
@@ -257,6 +271,20 @@ namespace :deb do
 
   desc "Ship the packages to the place"
   task :ship do
-    sh "rsync -avg pkg/deb/* #{@deb_rsync_url}"
+    cmd = %W[
+      rsync
+      --recursive
+      --hard-links
+      --links
+      --verbose
+      --omit-dir-times
+      --no-perms
+      --no-owner
+      --no-group
+      pkg/deb/*
+      #{@deb_rsync_url}
+    ].join(" ")
+
+    sh cmd
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,59 +1,65 @@
-require 'erb'
+#!/usr/bin/env ruby
 
-@name = 'puppetlabs-release'
+require "English"
+require "erb"
+require 'tmpdir'
+
+@name = "puppetlabs-release"
 @debversion = ENV["debversion"] ||= "1.0"
 @release = ENV["release"] ||= "12"
-@deb_dists = ["jessie", "precise", "squeeze", "trusty", "utopic", "wheezy"]
+@deb_dists = %w[jessie precise squeeze trusty utopic wheezy]
 @signwith = ENV["signwith"] ||= "4BD6EC30"
 @nosign ||= ENV["no_sign"]
-@signmacros = %{--define "%_gpg_name #{@signwith}"}
-@signmacros_el5 = %{--define "%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha1 --batch --no-verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}"}
+@signmacros = %(--define "%_gpg_name #{@signwith}")
+@signmacros_el5 = %(--define "%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha1 --batch --no-verbose --no-armor --passphrase-fd 3 --no-secmem-warning -u %{_gpg_name} -sbo %{__signature_filename} %{__plaintext_filename}")
 @rpm_rsync_url = ENV["rpm_rsync_url"] ||= "#{ENV["USER"]}@yum.puppetlabs.com:/opt/repository/yum"
 @deb_rsync_url = ENV["deb_rsync_url"] ||= "#{ENV["USER"]}@apt.puppetlabs.com:/opt/repository/incoming"
 
 @matrix = {
-  :el5 => { :dist => 'el', :codename => '5', :version => '5' },
-  :el6 => { :dist => 'el', :codename => '6', :version => '6' },
-  :el7 => { :dist => 'el', :codename => '7', :version => '7' },
-  :f20 => { :dist => 'fedora', :codename => 'f20', :version => '20' },
-  :f21 => { :dist => 'fedora', :codename => 'f21', :version => '21' },
+  el5: { dist: "el", codename: "5", version: "5" },
+  el6: { dist: "el", codename: "6", version: "6" },
+  el7: { dist: "el", codename: "7", version: "7" },
+  f20: { dist: "fedora", codename: "f20", version: "20" },
+  f21: { dist: "fedora", codename: "f21", version: "21" }
 }
 
-def get_temp
-  `mktemp -d -t tmpXXXXXX`.strip
+def tempdir
+  Dir.mktmpdir
 end
 
-def erb(erbfile,  outfile)
+def erb(erbfile, outfile)
   template = File.read(erbfile)
   message = ERB.new(template, nil, "-")
   output = message.result(binding)
-  File.open(outfile, 'w') { |f| f.write output }
+  File.open(outfile, "w") { |f| f.write output }
   puts "Generated: #{outfile}"
 end
 
-def cp_pr(src, dest, options={})
-  mandatory = {:preserve => true}
+def cp_pr(src, dest, options = {})
+  mandatory = { preserve: true }
   cp_r(src, dest, options.merge(mandatory))
 end
 
-def cp_p(src, dest, options={})
-  mandatory = {:preserve => true}
+def cp_p(src, dest, options = {})
+  mandatory = { preserve: true }
   cp(src, dest, options.merge(mandatory))
 end
 
-def mv_f(src, dest, options={})
-  force = {:force => true}
-  mv(src, dest, options.merge(mandatory))
+def mv_f(src, dest, options = {})
+  force = { force: true }
+  mv(src, dest, options.merge(force))
 end
 
 def populate_classvars(dist)
-  @version, @dist, @codename = @matrix[dist.to_sym][:version], @matrix[dist.to_sym][:dist],  @matrix[dist.to_sym][:codename]
+  @version = @matrix[dist.to_sym][:version]
+  @dist = @matrix[dist.to_sym][:dist]
+  @codename = @matrix[dist.to_sym][:codename]
 end
 
 def check_command(cmd)
-  %x{which #{cmd}}
-  unless $?.success?
-    STDERR.puts "#{cmd} command not found...exiting"
+  `which #{cmd}`
+  unless $CHILD_STATUS.success?
+    $stderr.puts "#{cmd} command not found...exiting"
     exit 1
   end
 end
@@ -61,12 +67,12 @@ end
 def build_rpm(dist)
   check_command "rpmbuild"
   populate_classvars dist
-  temp = get_temp
+  temp = tempdir
   rpm_define = "--define \"%dist .el5\" --define \"%_topdir  #{temp}\" "
   rpm_old_version = '--define "_source_filedigest_algorithm 1" --define "_binary_filedigest_algorithm 1" \
      --define "_binary_payload w9.gzdio" --define "_source_payload w9.gzdio" \
      --define "_default_patch_fuzz 2"'
-  args = rpm_define + ' ' + rpm_old_version
+  args = rpm_define + " " + rpm_old_version
   mkdir_p temp
   topdir = "pkg/rpm"
   base = "#{topdir}/#{@dist}/#{@codename}/products"
@@ -85,23 +91,21 @@ def build_rpm(dist)
   rm_rf temp
   puts
   puts "Wrote:"
-  output.each_line do | line |
-    puts "#{`pwd`.strip}/pkg/rpm/#{line.split('/')[-1]}"
+  output.each_line do |line|
+    puts "#{Dir.pwd}/pkg/rpm/#{line.split("/")[-1]}"
   end
 
   # This package is inherantly noarch, but we're building it on a 64-bit
   # mock and copying it into a 32-bit namespace for distribution.
-  mock = "#{@dist == 'el' ? 'pl-el' : 'pl-fedora'}-#{@version}-x86_64"
+  mock = "#{@dist == "el" ? "pl-el" : "pl-fedora"}-#{@version}-x86_64"
   sh "mock -r #{mock} #{base}/SRPMS/#{@name}-#{@version}-#{@release}.src.rpm"
-
-
 
   # Is this wrapped in an unless? Yes it is.
   # Why isn't #unless at the end of the command? because it's a very long line.
   # Why are we doing this? Because RHEL7 i386 doesn't exist yet and
   # populating this will just make an empty repo. We'll have to back this
   # out when CentOS drops a 32-bit EL7 release but in the mean time, kludge.
-  unless @dist == 'el' && @version == '7'
+  unless @dist == "el" && @version == "7"
     cp_pr "/var/lib/mock/#{mock}/result/#{@name}-#{@version}-#{@release}.noarch.rpm", "#{base}/i386/"
   end
 
@@ -112,7 +116,7 @@ end
 def build_deb(dist)
   check_command "dpkg-buildpackage"
   @dist = dist
-  temp = get_temp
+  temp = tempdir
   base = "pkg/deb/#{@dist}"
   mkdir_p base
   build_root = "#{temp}/puppetlabs-release_1.0"
@@ -124,21 +128,20 @@ def build_deb(dist)
   erb "templates/deb/changelog.erb", "#{build_root}/debian/changelog"
   cd build_root do
     sh "tar czf ../#{@name}_#{@debversion}.orig.tar.gz --exclude 'debian/*' *"
-    unless @nosign
-      sh "dpkg-buildpackage -k#{@signwith} -sa"
-    else
+    if @nosign
       sh "dpkg-buildpackage -uc -us -sa"
+    else
+      sh "dpkg-buildpackage -k#{@signwith} -sa"
     end
   end
-  cp_p FileList[ "#{temp}/*.deb", "#{temp}/*.changes", "#{temp}/*.debian.tar.gz", "#{temp}/*.dsc", "#{temp}/*.orig.tar.gz" ], base
+  cp_p FileList["#{temp}/*.deb", "#{temp}/*.changes", "#{temp}/*.debian.tar.gz", "#{temp}/*.dsc", "#{temp}/*.orig.tar.gz"], base
   rm_rf temp
 end
 
 def sign_rpm(rpm, type = nil)
   puts "Signing #{type.nil? ? "" : "(using el5 method)"} #{rpm}"
-  `./rpmsign-expects#{type.nil? ? "-rpm" : "-el5"} #{rpm} &> /dev/null`
+  sh "./rpmsign-expects#{type.nil? ? "-rpm" : "-el5"} #{rpm} &> /dev/null"
 end
-
 
 desc "Clean package artifacts"
 task :clean do
@@ -147,9 +150,9 @@ end
 
 desc "Check for a clean git tree"
 task :build_environment do
-  unless ENV['FORCE'] == '1'
+  unless ENV["FORCE"] == "1"
     modified = `git status --porcelain | sed -e '/^\?/d'`
-    if modified.split(/\n/).length != 0
+    unless modified.split(/\n/).empty?
       puts <<-HERE
 !! ERROR: Your git working directory is not clean. You must
 !! remove or commit your changes before you can create a package:
@@ -166,23 +169,23 @@ end
 desc "RPM tasks"
 namespace :rpm do
   desc "Build all the packages"
-  task :all => :build_environment do
-    @matrix.each do | k, v |
+  task all: :build_environment do
+    @matrix.each do |k, _v|
       build_rpm(k)
     end
   end
 
   desc "Build just one dist's release package"
-  task :single => :build_environment do
+  task single: :build_environment do
     unless ENV["DIST"]
-      STDERR.puts "DIST is required"
+      $stderr.puts "DIST is required"
       exit 1
     end
     build_rpm(ENV["DIST"])
   end
 
   desc "Ship the packages to the world"
-  task :ship => [:check] do
+  task ship: [:check] do
     sh "rsync -avg pkg/rpm/* #{@rpm_rsync_url}"
   end
 
@@ -191,16 +194,15 @@ namespace :rpm do
     unsigned = []
 
     # Get to the rpms
-    Dir["pkg/rpm/**/*"].select {|rpm| File.file?(rpm) }.each do | rpm |
-      %x{rpm --checksig #{rpm}}
-      unsigned << rpm unless $?.success?
-      unless unsigned.empty?
-        unsigned.each do |rpm|
-          STDERR.puts "#{rpm} is UNSIGNED"
-        end
-        STDERR.puts "Some rpms are unsigned. They must be signed before they can be shipped."
-        exit 1
+    Dir["pkg/rpm/**/*"].select { |rpm| File.file?(rpm) }.each do |rpm|
+      `rpm --checksig #{rpm}`
+      unsigned << rpm unless $CHILD_STATUS.success?
+      next if unsigned.empty?
+      unsigned.each do |pkg|
+        $stderr.puts "#{pkg} is UNSIGNED"
       end
+      $stderr.puts "Some rpms are unsigned. They must be signed before they can be shipped."
+      exit 1
     end
   end
 
@@ -225,8 +227,8 @@ namespace :rpm do
     chmod 0755, "rpmsign-expects-rpm"
 
     # Get to the rpms
-    Dir["pkg/rpm/**/*"].select {|rpm| File.file?(rpm) }.each do | rpm |
-      if rpm.match(/el\/5\//)
+    Dir["pkg/rpm/**/*"].select { |rpm| File.file?(rpm) }.each do |rpm|
+      if rpm =~ %r{el\/5\/}
         sign_rpm(rpm, :el5)
       else
         sign_rpm(rpm)
@@ -238,16 +240,16 @@ end
 desc "DEB tasks"
 namespace :deb do
   desc "Build one dist's debian release package"
-  task :single => :build_environment do
+  task single: :build_environment do
     unless ENV["DIST"]
-      STDERR.puts "DIST is required"
+      $stderr.puts "DIST is required"
       exit 1
     end
     build_deb(ENV["DIST"])
   end
 
   desc "Build all the debian release packages"
-  task :all => :build_environment do
+  task all: :build_environment do
     @deb_dists.each do |dist|
       build_deb(dist)
     end
@@ -258,4 +260,3 @@ namespace :deb do
     sh "rsync -avg pkg/deb/* #{@deb_rsync_url}"
   end
 end
-


### PR DESCRIPTION
This adds a `.rubocop.yaml` to the `master ` branch and fixes up the resulting Rubocop changes. Then it fixes the hostname and paths for shipping new puppetlabs-release packages.