### PR TITLE
(maint) Remove symlinking, fix sig check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -209,7 +209,7 @@ namespace :rpm do
 
     # Get to the rpms
     Dir["pkg/rpm/**/*"].select { |rpm| File.file?(rpm) }.each do |rpm|
-      `rpm --checksig #{rpm}`
+      `rpm -Kv #{rpm} | grep --ignore-case "#{@signwith}"`
       unsigned << rpm unless $CHILD_STATUS.success?
       next if unsigned.empty?
       unsigned.each do |pkg|

--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,6 @@ def build_rpm(dist)
   end
 
   cp_pr "/var/lib/mock/#{mock}/result/#{@name}-#{@version}-#{@release}.noarch.rpm", "#{base}/x86_64/"
-  ln_sf "#{base}/i386/#{@name}-#{@version}-#{@release}.noarch.rpm", "#{topdir}/#{@name}-#{@dist}-#{@version}.noarch.rpm"
 end
 
 def build_deb(dist)


### PR DESCRIPTION
Prior to this commit, this changes how the automation validates
signatures on our rpm packages. Previously, this was just checking the
return status of a command, but that was effectively always returning
true. This commit upates the check to ensrue the key we signed the
package with (or attempted to sign the package with) is actually present
and returned when we run `rpm -Kv`