### PR TITLE
(maint) Add rsync and fakeroot to Ubuntu 12.04 & 14.04

### DIFF
--- a/configs/platforms/ubuntu-12.04-amd64.rb
+++ b/configs/platforms/ubuntu-12.04-amd64.rb
@@ -4,7 +4,7 @@ platform "ubuntu-12.04-amd64" do |plat|
   plat.servicetype "sysv"
   plat.codename "precise"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1204-x86_64"
 end

--- a/configs/platforms/ubuntu-14.04-amd64.rb
+++ b/configs/platforms/ubuntu-14.04-amd64.rb
@@ -4,7 +4,7 @@ platform "ubuntu-14.04-amd64" do |plat|
   plat.servicetype "sysv"
   plat.codename "trusty"
 
-  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper "
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot "
   plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
   plat.vmpooler_template "ubuntu-1404-x86_64"
 end


### PR DESCRIPTION
The templates for Ubuntu 12.04 and 14.04 were updated and no longer include these packages by default.  They need to be explicitly defined.