### PR TITLE
(maint) Set all release packages to same version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -161,7 +161,7 @@ def build_deb(dist)
   temp = tempdir
   base = "pkg/deb/#{@dist}"
   mkdir_p base
-  build_root = "#{temp}/puppetlabs-release_1.0"
+  build_root = "#{temp}/puppetlabs-release_#{@debversion}"
   mkdir_p build_root
   cp_p "files/puppetlabs-keyring.gpg", build_root
   cp_p "files/puppetlabs-nightly-keyring.gpg", build_root

--- a/templates/redhat/puppetlabs-release.spec.erb
+++ b/templates/redhat/puppetlabs-release.spec.erb
@@ -1,5 +1,5 @@
 Name:           <%= @name %>
-Version:        <%= @version %>
+Version:        <%= @rpmversion %>
 Release:        <%= @release %>
 Summary:        Configuration for yum.puppetlabs.com
 
@@ -19,8 +19,8 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 Requires:       redhat-release >=  %{version}
 
-Provides:       puppetlabs-release-devel >= <%= @version -%>-2
-Obsoletes:      puppetlabs-release-devel <= <%= @version -%>-1
+Provides:       puppetlabs-release-devel >= <%= @dist_version -%>-2
+Obsoletes:      puppetlabs-release-devel <= <%= @dist_version -%>-1
 
 %description
 This package contains the yum.puppetlabs.com repository
@@ -59,14 +59,14 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @version %>-<%= @release %>
-- Build for <%= @version %>
+* <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @release %>
+- Build for <%= @rpmversion %>
 
 * Fri Aug 22 2014 Matthaus Owens <matthaus@puppetlabs.com>
 - Add nightly key to puppetlabs-release package
 
-* Thu Jun 28 2012 Matthaus Litteken <matthaus@puppetlabs.com> -  <%= @version -%>-2
+* Thu Jun 28 2012 Matthaus Litteken <matthaus@puppetlabs.com> -  <%= @rpmversion -%>-2
 - Update %files section, obsolete devel package
 
-* Sat Sep 24 2011 Michael Stahnke <stahnma@puppetlabs.com> -  <%= @version -%>-1
+* Sat Sep 24 2011 Michael Stahnke <stahnma@puppetlabs.com> -  <%= @rpmversion -%>-1
 - Initial Package

--- a/templates/redhat/puppetlabs.repo.erb
+++ b/templates/redhat/puppetlabs.repo.erb
@@ -1,26 +1,26 @@
 [puppetlabs-products]
-name=Puppet Labs Products <%= @dist.capitalize -%> <%= @version -%> - $basearch
+name=Puppet Labs Products <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/products/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 enabled=1
 gpgcheck=1
 
 [puppetlabs-deps]
-name=Puppet Labs Dependencies <%= @dist.capitalize -%> <%= @version -%> - $basearch
+name=Puppet Labs Dependencies <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/dependencies/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 enabled=1
 gpgcheck=1
 
 [puppetlabs-devel]
-name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @version -%> - $basearch
+name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/devel/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 enabled=0
 gpgcheck=1
 
 [puppetlabs-products-source]
-name=Puppet Labs Products <%= @dist.capitalize -%> <%= @version -%> - $basearch - Source
+name=Puppet Labs Products <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch - Source
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/products/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 failovermethod=priority
@@ -28,14 +28,14 @@ enabled=0
 gpgcheck=1
 
 [puppetlabs-deps-source]
-name=Puppet Labs Source Dependencies <%= @dist.capitalize -%> <%= @version -%> - $basearch - Source
+name=Puppet Labs Source Dependencies <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch - Source
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/dependencies/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 enabled=0
 gpgcheck=1
 
 [puppetlabs-devel-source]
-name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @version -%> - $basearch - Source
+name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch - Source
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/devel/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 enabled=0


### PR DESCRIPTION
Prior to this commit, we were versioning the puppetlabs release packages
based on the platform version we were building them for. This was fine,
except it removed the ability to increment anything but the release
number. We are getting ready to make a large change to this package, but
in order to best to that, we should be able to increment the major or
minor version of the package. Unfortunately, due to the previous
versioning convention, we have to just increment the major version so
all the packages use the same one. Go us!