### PR TITLE
(maint) Remove check task for build_environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -223,7 +223,7 @@ namespace :rpm do
   end
 
   desc "Ship the packages to the world"
-  task ship: [:check] do
+  task ship: :build_environment do
     cmd = %W[
       rsync
       --recursive


### PR DESCRIPTION
The check command doesn't exist, and when you try to run the rpm:ship
task, it fails. I assume this was a refactoring typo.