### PR TITLE
(maint) Fix path structure assumptions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -117,7 +117,7 @@ def build_rpm(dist)
      --define "_default_patch_fuzz 2"'
   args = rpm_define + " " + rpm_old_version
   mkdir_p temp
-  topdir = "pkg"
+  topdir = "pkg/rpm"
   base = "#{topdir}/#{@dist}/#{@codename}/products"
   mkdir_p "#{base}/SRPMS"
   mkdir_p "#{base}/i386"


### PR DESCRIPTION
The ship assumes that the path to the package contains 'rpm'. This isn't
how it is. This commit adds the rpm directory to the path as the ship
expects, because that's the easiest thing to do.