### PR TITLE
(maint) Fix major typo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ end
 # a standard release package with consistent versions across platforms, we
 # get to set this version to 22. Blarg.
 @rpmversion = ENV["rpmversion"] ||= "22.0"
-@release = ENV["release"] ||= "1"
+@release = ENV["release"] ||= "2"
 @deb_dists = %w[jessie precise squeeze trusty utopic wheezy]
 @signwith = ENV["signwith"] ||= "4BD6EC30"
 @nosign ||= ENV["no_sign"]

--- a/templates/redhat/puppetlabs-release.spec.erb
+++ b/templates/redhat/puppetlabs-release.spec.erb
@@ -18,10 +18,10 @@ Source3:        puppetlabs.repo
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch:      noarch
-Requires:       redhat-release >=  %{version}
+Requires:       redhat-release >=  <%= @plat_version -%>
 
-Provides:       puppetlabs-release-devel >= <%= @dist_version -%>-2
-Obsoletes:      puppetlabs-release-devel <= <%= @dist_version -%>-1
+Provides:       puppetlabs-release-devel >= <%= @plat_version -%>-2
+Obsoletes:      puppetlabs-release-devel <= <%= @plat_version -%>-1
 
 %description
 This package contains the yum.puppetlabs.com repository

--- a/templates/redhat/puppetlabs.repo.erb
+++ b/templates/redhat/puppetlabs.repo.erb
@@ -1,5 +1,5 @@
 [puppetlabs-products]
-name=Puppet Labs Products <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch
+name=Puppet Labs Products <%= @dist.capitalize -%> <%= @plat_version -%> - $basearch
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/products/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
        file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet
@@ -7,7 +7,7 @@ enabled=1
 gpgcheck=1
 
 [puppetlabs-deps]
-name=Puppet Labs Dependencies <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch
+name=Puppet Labs Dependencies <%= @dist.capitalize -%> <%= @plat_version -%> - $basearch
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/dependencies/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
        file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet
@@ -15,7 +15,7 @@ enabled=1
 gpgcheck=1
 
 [puppetlabs-devel]
-name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch
+name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @plat_version -%> - $basearch
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/devel/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
        file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet
@@ -23,7 +23,7 @@ enabled=0
 gpgcheck=1
 
 [puppetlabs-products-source]
-name=Puppet Labs Products <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch - Source
+name=Puppet Labs Products <%= @dist.capitalize -%> <%= @plat_version -%> - $basearch - Source
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/products/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
        file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet
@@ -32,7 +32,7 @@ enabled=0
 gpgcheck=1
 
 [puppetlabs-deps-source]
-name=Puppet Labs Source Dependencies <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch - Source
+name=Puppet Labs Source Dependencies <%= @dist.capitalize -%> <%= @plat_version -%> - $basearch - Source
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/dependencies/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
        file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet
@@ -40,7 +40,7 @@ enabled=0
 gpgcheck=1
 
 [puppetlabs-devel-source]
-name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @dist_version -%> - $basearch - Source
+name=Puppet Labs Devel <%= @dist.capitalize -%> <%= @plat_version -%> - $basearch - Source
 baseurl=http://yum.puppetlabs.com/<%= @dist.downcase -%>/<%= @codename -%>/devel/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
        file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet


### PR DESCRIPTION
This fixes a major issue with our release packages. There's a dependency
on redhat-release that's based on the platform version. However, when we
changed the platform version to not be the package version, this broke
that logic. This commit hopefully fixes it.