### PR TITLE
Alter release spec file to depend on platform version

### DIFF
--- a/templates/redhat/puppetlabs-release.spec.erb
+++ b/templates/redhat/puppetlabs-release.spec.erb
@@ -18,7 +18,7 @@ Source3:        puppetlabs.repo
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch:      noarch
-Requires:       redhat-release >=  %{version}
+Requires:       redhat-release >=  %{plat_version}
 
 Provides:       puppetlabs-release-devel >= <%= @dist_version -%>-2
 Obsoletes:      puppetlabs-release-devel <= <%= @dist_version -%>-1


### PR DESCRIPTION
The recent commit [1] to modify the release package code caused a regression
which caused OpenStack Puppet to fail. [2] This was caused by an erroneous
Requires statement in the spec file. Although the package is correct,
the version required was wildly incorrect.

This patch alters the Depends line to use the plat_version variable,
which should match the platform.

[1]
https://github.com/puppetlabs/puppetlabs-release/commit/6027433ce8fb94f93782b375b353a546f24f7dce