### PR TITLE
(maint) Add PC1 suffix to nightly key

### DIFF
--- a/configs/components/gpg_key.rb
+++ b/configs/components/gpg_key.rb
@@ -10,6 +10,6 @@ component 'gpg_key' do |pkg, settings, platform|
     pkg.add_source("file://files/RPM-GPG-KEY-nightly-puppetlabs")
     pkg.install_file 'RPM-GPG-KEY-puppetlabs.gpg', '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1'
     pkg.install_file 'RPM-GPG-KEY-puppet.asc', '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1'
-    pkg.install_file 'RPM-GPG-KEY-nightly-puppetlabs', '/etc/pki/rpm-gpg/RPM-GPG-KEY-nightly-puppetlabs'
+    pkg.install_file 'RPM-GPG-KEY-nightly-puppetlabs', '/etc/pki/rpm-gpg/RPM-GPG-KEY-nightly-puppetlabs-PC1'
   end
 end

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,6 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
-  proj.release '1'
+  proj.release '2'
   proj.license 'ASL 2.0'
   proj.version '1.1.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'


### PR DESCRIPTION
Users in some cases need to install both the PC1 and "old school"
release packages on the same machine. The only issue is with conflicts
because both packages install the same keys. This is fine to have
duplicate keys installed, but rpm bails out when the files have the same
name. That's why we had to add the PC1 suffix to the puppet and
puppetlabs keys. We forgot to do the same for the nightly key. This
commit fixes that.