### PR TITLE
(RE-7959) Provide sles release packages

### DIFF
--- a/configs/components/gpg_key.rb
+++ b/configs/components/gpg_key.rb
@@ -11,5 +11,15 @@ component 'gpg_key' do |pkg, settings, platform|
     pkg.install_file 'RPM-GPG-KEY-puppetlabs.gpg', '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1'
     pkg.install_file 'RPM-GPG-KEY-puppet.asc', '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1'
     pkg.install_file 'RPM-GPG-KEY-nightly-puppetlabs', '/etc/pki/rpm-gpg/RPM-GPG-KEY-nightly-puppetlabs-PC1'
+
+    # SLES doesn't automagically import gpg keys even if they're defined in
+    # the repo file. Because of this we need to import the keys in a postinst
+    # script. This keeps the sles workflow consistent with other rpm based
+    # platforms
+    if platform.is_sles?
+      pkg.add_postinstall_action ["install"],
+        ['rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1',
+         'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1']
+    end
   end
 end

--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -13,6 +13,8 @@ component 'repo_definition' do |pkg, settings, platform|
     # way to go if anything else needs to get added here:
     if platform.is_cisco_wrlinux?
       repo_path = '/etc/yum/repos.d'
+    elsif platform.is_sles?
+      repo_path = '/etc/zypp/repos.d'
     else
       repo_path = '/etc/yum.repos.d'
     end
@@ -20,8 +22,18 @@ component 'repo_definition' do |pkg, settings, platform|
     pkg.url 'file://files/puppetlabs.repo.txt'
     pkg.md5sum 'c5b79dc2f8a13d710a17e5f3ca502376'
     pkg.install_configfile 'puppetlabs.repo.txt', "#{repo_path}/puppetlabs-pc1.repo"
+
+    install_hash = ["sed -i -e 's|__OS_NAME__|#{platform.os_name}|g' -e 's|__OS_VERSION__|#{platform.os_version}|g' #{repo_path}/puppetlabs-pc1.repo"]
+
+    # The repo definion on sles is invalid unless each gpg key begins with a
+    # a '='. This isn't the case for other rpm platforms, so we get to modify
+    # the repo file after we install it on sles.
+    if platform.is_sles?
+      install_hash << "sed -i -e 's|file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1|=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1|g' #{repo_path}/puppetlabs-pc1.repo"
+    end
+
     pkg.install do
-      "sed -i -e 's|__OS_NAME__|#{platform.os_name}|g' -e 's|__OS_VERSION__|#{platform.os_version}|g' #{repo_path}/puppetlabs-pc1.repo"
+      install_hash
     end
   end
 end

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -1,0 +1,9 @@
+platform "sles-11-x86_64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.vmpooler_template "sles-11-x86_64"
+end

--- a/configs/platforms/sles-12-x86_64.rb
+++ b/configs/platforms/sles-12-x86_64.rb
@@ -1,0 +1,9 @@
+platform "sles-12-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "zypper -n --no-gpg-checks install -y aaa_base autoconf automake rsync gcc make rpm-build"
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.vmpooler_template "sles-12-x86_64"
+end


### PR DESCRIPTION
We recently added sles repos to yum.puppetlabs.com. In order to keep the
workflow for these new repos consistent with other rpm based platforms,
we need to provide release packages for these repos. However, because
sles and zypper like to make things interesting, there are a few tweaks
we need to make to these packages. Yay sles!

Signed-off-by: Melissa Stone <melissa@puppet.com>