### PR TITLE
(maint) Only attempt to import the keys on sles 12

### DIFF
--- a/configs/components/gpg_key.rb
+++ b/configs/components/gpg_key.rb
@@ -1,5 +1,5 @@
 component 'gpg_key' do |pkg, settings, platform|
-  pkg.version '2016.08.19'
+  pkg.version '2016.10.03'
 
   if platform.is_deb?
     pkg.add_source 'file://files/puppetlabs-keyring.gpg'
@@ -17,9 +17,11 @@ component 'gpg_key' do |pkg, settings, platform|
     # script. This keeps the sles workflow consistent with other rpm based
     # platforms
     if platform.is_sles?
-      pkg.add_postinstall_action ["install"],
-        ['rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1',
-         'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1']
+      if platform.os_version >= "12"
+        pkg.add_postinstall_action ["install"],
+          ['rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1',
+           'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1']
+      end
     end
   end
 end

--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -1,5 +1,5 @@
 component 'repo_definition' do |pkg, settings, platform|
-  pkg.version '2015.09.28'
+  pkg.version '2016.10.03'
 
   if platform.is_deb?
     pkg.url 'file://files/puppetlabs.list.txt'

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,6 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
-  proj.release '2'
+  proj.release '3'
   proj.license 'ASL 2.0'
   proj.version '1.1.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'


### PR DESCRIPTION
Prior to this commit, I was having issues installing the puppet release
packages on sles 11. The issue wasn't preventing the installation of
the packages, but it looks bad and it takes a long time to complete. It
only happens when we try to import the gpg keys during the postinstall
on sles 11.

```
warning: waiting for exclusive lock on /var/lib/rpm/Packages
error: cannot get exclusive lock on /var/lib/rpm/Packages
error: cannot open Packages index using db3 - Operation not permitted (1)
error: cannot open Packages database in /var/lib/rpm
error: /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1: import failed.
```

Importing the keys was only a means to keep the sles release packages
in line with other platform release packages. When the keys are not
installed, the user must manually import them to make them available.
If the user does not manually import the keys, zypper will simply
complain the key to verify the signature is not available. Without this
change, zypper still complains about the unavailable key on sles 11.

This commit also updates the project release and all the component
versions as I had forgotten to do that last time.

Signed-off-by: Melissa Stone <melissa@puppet.com>