### PR TITLE
(CPR-383) Remove gpg key import on sles

### DIFF
--- a/configs/components/gpg_key.rb
+++ b/configs/components/gpg_key.rb
@@ -1,5 +1,5 @@
 component 'gpg_key' do |pkg, settings, platform|
-  pkg.version '2016.10.03'
+  pkg.version '2016.10.05'
 
   if platform.is_deb?
     pkg.add_source 'file://files/puppetlabs-keyring.gpg'
@@ -12,16 +12,5 @@ component 'gpg_key' do |pkg, settings, platform|
     pkg.install_file 'RPM-GPG-KEY-puppet.asc', '/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1'
     pkg.install_file 'RPM-GPG-KEY-nightly-puppetlabs', '/etc/pki/rpm-gpg/RPM-GPG-KEY-nightly-puppetlabs-PC1'
 
-    # SLES doesn't automagically import gpg keys even if they're defined in
-    # the repo file. Because of this we need to import the keys in a postinst
-    # script. This keeps the sles workflow consistent with other rpm based
-    # platforms
-    if platform.is_sles?
-      if platform.os_version >= "12"
-        pkg.add_postinstall_action ["install"],
-          ['rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-PC1',
-           'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs-PC1']
-      end
-    end
   end
 end

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,6 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
-  proj.release '3'
+  proj.release '4'
   proj.license 'ASL 2.0'
   proj.version '1.1.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'


### PR DESCRIPTION
So sles doesn't automatically import gpg keys when you use a repo for
the first time. To fix this, I included a postinst script to manually
import the keys for the user. This worked when I tested on sles 12, but
not on sles 11. It turns out the version of rpm on sles 11 isn't smart
enough to be able to call rpm within rpm, so it couldn't handle it. Sles
12 seemed to be smarter and able to handle this situation. However, it
seems some users are on older, less-updated versions of sles 12 and are
running into the issue we had seen on sles 11.

I give up, ya'll can just manually import the gpg keys yourselves.