### PR TITLE
(CPR-393) Bump release

### DIFF
--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,6 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
-  proj.release '4'
+  proj.release '5'
   proj.license 'ASL 2.0'
   proj.version '1.1.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'


### PR DESCRIPTION
This will let us pick up new `%pre` & `%post` requirements from Vanagon.

(This will require a Vanagon release that includes commit [61d5d36a](https://github.com/puppetlabs/vanagon/commit/61d5d36ae006e16e95cb56a406479e129f1397f9))