### PR TITLE
Update Gemfile & pin to newer Vanagon release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,21 @@
 source 'https://rubygems.org'
 
 def vanagon_location_for(place)
-  if place =~ /^(git[:@][^#]*)#(.*)/
-    [{ :git => $1, :branch => $2, :require => false }]
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
-  elsif place =~ /(\d+\.\d+\.\d+)/
-    [$1, {:git => 'git@github.com:puppetlabs/vanagon', :tag => $1}]
+  git_repo = /^(git[:@][^#]*)#(.*)/
+  file_uri = %r{^file:\/\/(.*)}
+  version_number = /(\d+\.\d+\.\d+)/
+  if place =~ git_repo
+    [{ git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }]
+  elsif place =~ file_uri
+    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
+  elsif place =~ version_number
+    [Regexp.last_match(1), { git: 'https://github.com/puppetlabs/vanagon.git', tag: Regexp.last_match(1) }]
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')
-gem 'packaging', '~> 0.4', :github => 'puppetlabs/packaging'
 gem 'json'
+gem 'packaging', '~> 0.4', git: 'https://github.com/puppetlabs/packaging.git'
 gem 'rake'
+# We should use a minimum specific Vanagon verson, but
+#  allow it to rev upwards within a given Y release series
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,4 @@ gem 'packaging', '~> 0.4', git: 'https://github.com/puppetlabs/packaging.git'
 gem 'rake'
 # We should use a minimum specific Vanagon verson, but
 #  allow it to rev upwards within a given Y release series
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')
+gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.9.1')


### PR DESCRIPTION
Pinning to Vanagon 0.9.1 or newer will allow us to rebuild `puppetlabs-release` RPMs with the [upstream RPM dependency fix](https://github.com/puppetlabs/vanagon/commit/61d5d36ae006e16e95cb56a406479e129f1397f9).

`Gemfile` just gotten jostled around a bit because some of it was out of date and this was a safe place to poke around without disturbing more active repos. The `vanagon_location_for` function will hopefully be refactored right out soon, but until then it should at least be kept up to date and well structured.