### PR TITLE
Add Ubuntu 16.10 (yakkety) platform, and enable package pinning for puppet-agent

### DIFF
--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -5,6 +5,15 @@ component 'repo_definition' do |pkg, settings, platform|
     pkg.url 'file://files/puppetlabs.list.txt'
     pkg.md5sum '53d2e1455bab67b4a49a5d0969ebbb95'
     pkg.install_configfile 'puppetlabs.list.txt', '/etc/apt/sources.list.d/puppetlabs-pc1.list'
+  if platform.name =~ /^ubuntu-16.10/
+    # Ubuntu 16.10 shipped with a puppet-agent package that was versioned based
+    # on the included version of puppet. This means the distro package would
+    # override Puppet Inc's puppet-agent AIO package version. We are working
+    # around this by pinning our puppet-agent package to a higher priority in
+    # this preferences config fragment:
+    pkg.add_source 'file://files/puppetlabs-puppet-agent-pin-990.txt', sum: '713257941eb9e3fae798d4faebd1a995'
+    pkg.install_configfile 'puppetlabs-puppet-agent-pin-990.txt', '/etc/apt/preferences.d/puppetlabs-pc1-puppet-agent-pin-990'
+  end
     pkg.install do
       "sed -i 's|__CODENAME__|#{platform.codename}|g' /etc/apt/sources.list.d/puppetlabs-pc1.list"
     end

--- a/configs/platforms/ubuntu-16.10-amd64.rb
+++ b/configs/platforms/ubuntu-16.10-amd64.rb
@@ -1,0 +1,10 @@
+platform "ubuntu-16.10-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "yakkety"
+
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1610-x86_64"
+end

--- a/files/puppetlabs-puppet-agent-pin-990.txt
+++ b/files/puppetlabs-puppet-agent-pin-990.txt
@@ -1,0 +1,8 @@
+# Ubuntu 16.10 shipped with a puppet-agent package that was versioned based
+# on the included version of puppet. This means the distro package would
+# override Puppet Inc's puppet-agent AIO package version. We are working
+# around this by pinning our puppet-agent package to a higher priority in
+# this preferences config fragment:
+Package: puppet-agent
+Pin: origin "apt.puppetlabs.com"
+Pin-Priority: 990


### PR DESCRIPTION
Ubuntu 16.10 shipped with a puppet-agent package that was versioned based on the included version of puppet. This means the distro package would override Puppet Inc's puppet-agent AIO package version. We are working around this by pinning our puppet-agent package to a higher priority in an apt preferences config file.

I've tested this by creating a simple apt repository on a vmpooler host and modifying the urls to point to that instead of apt.puppetlabs.com. If the distro puppet-agent package hasn't been installed yet, this does the right thing and installs our AIO puppet-agent package. :+1: 

However, if the distro puppet-agent package is already installed, apt will not automatically upgrade or install our AIO package over the distro version. To my understanding of how package pinning works, I don't think we can force the behavior we want in that scenario. :-1: 
