### PR TITLE
(maint) Add conflicts on puppet-release and puppet-nightly-release

### DIFF
--- a/configs/projects/puppet5-nightly-release.rb
+++ b/configs/projects/puppet5-nightly-release.rb
@@ -1,12 +1,15 @@
 project 'puppet5-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '1'
+  proj.release '2'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'
   proj.homepage 'https://www.puppet.com'
   proj.target_repo 'puppet5-nightly'
   proj.noarch
+
+  proj.conflicts 'puppet-release'
+  proj.conflicts 'puppet-nightly-release'
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'


### PR DESCRIPTION
We want to make sure people are either using the individual numbered
repos (i.e., puppet5, puppet6, etc.) or they're using the rolling
symlinked repos. Not both.