### PR TITLE
(RE-9690) Remove EOL platform definitions

### DIFF
--- a/configs/platforms/fedora-f24-x86_64.rb
+++ b/configs/platforms/fedora-f24-x86_64.rb
@@ -1,9 +1,0 @@
-platform "fedora-f24-x86_64" do |plat|
-  plat.servicedir "/usr/lib/systemd/system"
-  plat.defaultdir "/etc/sysconfig"
-  plat.servicetype "systemd"
-
-  plat.provision_with "/usr/bin/dnf install -y --best --allowerasing autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
-  plat.install_build_dependencies_with "/usr/bin/dnf install -y --best --allowerasing"
-  plat.vmpooler_template "fedora-24-x86_64"
-end


### PR DESCRIPTION
This commit removes the platform config for fedora 24.