### PR TITLE
(maint) Fix apt repo url

### DIFF
--- a/configs/projects/puppet5-nightly-release.rb
+++ b/configs/projects/puppet5-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet5-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '3'
+  proj.release '4'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/files/puppet5-nightly.list.txt
+++ b/files/puppet5-nightly.list.txt
@@ -1,9 +1,9 @@
 # Puppet 5 Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com apt __CODENAME__ puppet5-nightly
+deb http://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly
 
 # Puppet 5 Nightly __CODENAME__ Source Repository
 # The source repos are commented out by default because we
 # do not always make sources available for all packages or
 # for all platforms. If you want to access the source repos,
 # uncomment the following line.
-#deb-src http://nightlies.puppet.com apt __CODENAME__ puppet5-nightly
+#deb-src http://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly


### PR DESCRIPTION
This commit adjusts the apt repo url to point to the apt directory on nightlies. Before, the nightlies base url was being treated as the apt url and files were not being found correctly.