### PR TITLE
(maint) Fix apt repo url

### DIFF
--- a/configs/projects/puppet-nightly-release.rb
+++ b/configs/projects/puppet-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '1'
+  proj.release '2'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/files/puppet-nightly.list.txt
+++ b/files/puppet-nightly.list.txt
@@ -1,9 +1,9 @@
 # Puppet Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com apt __CODENAME__ puppet-nightly
+deb http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly
 
 # Puppet Nightly __CODENAME__ Source Repository
 # The source repos are commented out by default because we
 # do not always make sources available for all packages or
 # for all platforms. If you want to access the source repos,
 # uncomment the following line.
-#deb-src http://nightlies.puppet.com apt __CODENAME__ puppet-nightly
+#deb-src http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly


### PR DESCRIPTION
This commit adjusts the apt repo url to point to the apt directory on nightlies. Before, the nightlies base url was being treated as the apt url and files were not being found correctly.