### PR TITLE
(maint) Add repo config for fedora-f26-x86_64

### DIFF
--- a/configs/platforms/fedora-f26-x86_64.rb
+++ b/configs/platforms/fedora-f26-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-26-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+  plat.dist "fc26"
+
+  plat.provision_with "dnf clean metadata && dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "dnf install -y"
+  plat.vmpooler_template "fedora-26-x86_64"
+end


### PR DESCRIPTION
This commit duplicates the fedora-26-x86_64 config to have an f-prefixed version. This will allow us to have working release packages for fedora until CPR-391 and friends get resolved.