### PR TITLE
(PA-1779) Add support for fedora-27-x86_64

### DIFF
--- a/configs/platforms/fedora-f27-x86_64.rb
+++ b/configs/platforms/fedora-f27-x86_64.rb
@@ -1,0 +1,9 @@
+platform "fedora-f27-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "dnf clean metadata && dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "dnf install -y"
+  plat.vmpooler_template "fedora-27-x86_64"
+end

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,6 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the Puppet Labs PC1 repository'
-  proj.release '5'
+  proj.release '6'
   proj.license 'ASL 2.0'
   proj.version '1.1.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'


### PR DESCRIPTION
Platform config was copied from the fedora-26 one.