### PR TITLE
(maint) Remove repo_link_target

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -7,5 +7,4 @@ gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 vanagon_project: TRUE
 repo_name: 'puppet5-nightly'
-repo_link_target: 'puppet-nightly'
 build_tar: FALSE


### PR DESCRIPTION
This commit removes the repo_link_target param from build_defaults. Since we have started shipping things to puppet6-nightly repos, we don't want shipping puppet5-nightly artifacts to overwrite the link from puppet6-nightly to puppet-nightly.