### PR TITLE
(BUILD-148) Add support for Ubuntu 18.04

### DIFF
--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -1,0 +1,10 @@
+platform "ubuntu-18.04-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "bionic"
+
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1804-x86_64"
+end


### PR DESCRIPTION
Here's a platform definition to add Ubuntu 18.04 - if this looks alright, I can open PRs for the other branches as well (puppet5-nightly, puppet6, and puppet6-nightly, right?)