### PR TITLE
(maint) Use packaging#1.0.x

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,6 @@
 ---
 project: 'pl-build-tools-release'
-packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
+packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=1.0.x'
 packaging_repo: 'packaging'
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'


### PR DESCRIPTION
This commit changes the packaging branch to 1.0.x, which has many improvements
to our shipping automation. This repo is not quite set up to use packaging as a
gem yet.