### PR TITLE
(CPR-581) Add nightly support for Ubuntu-18.04 (bionic)

### DIFF
--- a/configs/platforms/ubuntu-18.04-amd64.rb
+++ b/configs/platforms/ubuntu-18.04-amd64.rb
@@ -1,0 +1,10 @@
+platform "ubuntu-18.04-amd64" do |plat|
+  plat.servicedir "/lib/systemd/system"
+  plat.defaultdir "/etc/default"
+  plat.servicetype "systemd"
+  plat.codename "bionic"
+
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends build-essential devscripts make quilt pkg-config debhelper rsync fakeroot"
+  plat.install_build_dependencies_with "DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends "
+  plat.vmpooler_template "ubuntu-1804-x86_64"
+end


### PR DESCRIPTION
Copied from the existing config on the puppet5 branch.