### PR TITLE
(PA-1862) Add support for fedora-28-x86_64

### DIFF
--- a/configs/platforms/fedora-28-x86_64.rb
+++ b/configs/platforms/fedora-28-x86_64.rb
@@ -1,0 +1,10 @@
+platform "fedora-28-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+  plat.dist "fc28"
+
+  plat.provision_with "dnf clean metadata && dnf install -y autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+  plat.install_build_dependencies_with "dnf install -y"
+  plat.vmpooler_template "fedora-28-x86_64"
+end


### PR DESCRIPTION
Copied the fedora-27-x86_64 config.