### PR TITLE
(maint) Use packaging as a gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.local
 ext/packaging
 pkg/*
 ext/packaging
+ext/build_metadata.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,18 @@
 source 'https://rubygems.org'
 
-def vanagon_location_for(place)
-  git_repo = /^(git[:@][^#]*)#(.*)/
-  file_uri = %r{^file:\/\/(.*)}
-  version_number = /(\d+\.\d+\.\d+)/
-  if place =~ git_repo
-    [{ git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }]
-  elsif place =~ file_uri
-    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
-  elsif place =~ version_number
-    [Regexp.last_match(1), { git: 'https://github.com/puppetlabs/vanagon.git', tag: Regexp.last_match(1) }]
+def location_for(place)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [{ :git => $1, :branch => $2, :require => false }]
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
   end
 end
 
 gem 'json'
-gem 'packaging', git: 'https://github.com/puppetlabs/packaging.git', branch: '1.0.x'
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99.8')
 gem 'rake'
 # We should use a minimum specific Vanagon verson, but
 #  allow it to rev upwards within a given Y release series
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || '~> 0.14.1')
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.14.1')

--- a/Rakefile
+++ b/Rakefile
@@ -1,38 +1,12 @@
-RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
+require 'packaging'
 
-begin
-  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
-rescue LoadError
-end
+Pkg::Util::RakeUtils.load_packaging_tasks
 
-build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
-if File.exist?(build_defs_file)
-  begin
-    require 'yaml'
-    @build_defaults ||= YAML.load_file(build_defs_file)
-  rescue Exception => e
-    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
-    raise e
+namespace :package do
+  task :bootstrap do
+    puts 'Bootstrap is no longer needed, using packaging-as-a-gem'
   end
-  @packaging_url  = @build_defaults['packaging_url']
-  @packaging_repo = @build_defaults['packaging_repo']
-  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
-  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
-
-  namespace :package do
- #   desc "Bootstrap packaging automation, e.g. clone into packaging repo"
-    task :bootstrap do
-      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
-        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
-      else
-        cd File.join(RAKE_ROOT, 'ext') do
-          %x{git clone #{@packaging_url}}
-        end
-      end
-    end
- #   desc "Remove all cloned packaging automation"
-    task :implode do
-      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
-    end
+  task :implode do
+    puts 'Implode is no longer needed, using packaging-as-a-gem'
   end
 end


### PR DESCRIPTION
This commit updates the `vanagon_location_for` method to be more generic and
makes use of it (now `location_for`) when setting the packaging dependency.