### PR TITLE
(maint) Update vanagon and packaging dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 source 'https://rubygems.org'
 
-def vanagon_location_for(place)
+def location_for(place)
   if place =~ /^(git[:@][^#]*)#(.*)/
     [{ :git => $1, :branch => $2, :require => false }]
   elsif place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]
-  elsif place =~ /(\d+\.\d+\.\d+)/
-    [$1, {:git => 'git@github.com:puppetlabs/vanagon', :tag => $1}]
+  else
+    [place, { :require => false }]
   end
 end
 
-gem 'vanagon', *vanagon_location_for(ENV['VANAGON_LOCATION'] || 'git@github.com:puppetlabs/vanagon#master')
-gem 'packaging', '0.99.4', :github => 'puppetlabs/packaging', :tag => '0.99.4'
+gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.15')
+gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 gem 'json'
 gem 'rake'


### PR DESCRIPTION
This commit updates the `vanagon_location_for` method to be more generic and
makes use of this new `location_for` method to set gem versions for vanagon and
packaging. This commit also updates these dependencies to be loosely pinned so
that new non-major gem versions will automatically get pulled in.