### PR TITLE
(maint) Use packaging as a gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,38 +1,12 @@
-RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
+require 'packaging'
 
-begin
-  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
-rescue LoadError
-end
+Pkg::Util::RakeUtils.load_packaging_tasks
 
-build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
-if File.exist?(build_defs_file)
-  begin
-    require 'yaml'
-    @build_defaults ||= YAML.load_file(build_defs_file)
-  rescue Exception => e
-    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
-    raise e
+namespace :package do
+  task :bootstrap do
+    puts 'Bootstrap is no longer needed, using packaging as a gem.'
   end
-  @packaging_url  = @build_defaults['packaging_url']
-  @packaging_repo = @build_defaults['packaging_repo']
-  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
-  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
-
-  namespace :package do
- #   desc "Bootstrap packaging automation, e.g. clone into packaging repo"
-    task :bootstrap do
-      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
-        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
-      else
-        cd File.join(RAKE_ROOT, 'ext') do
-          %x{git clone #{@packaging_url}}
-        end
-      end
-    end
- #   desc "Remove all cloned packaging automation"
-    task :implode do
-      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
-    end
+  task :implode do
+    puts 'Implode is no longer needed, using packaging as a gem.'
   end
 end


### PR DESCRIPTION
This commit updates the Rakefile to require packaging and pull in the packaging
rake tasks via a library method, rather than using the old bootstrap method.