### PR TITLE
(RE-12316) Update READMEs

### DIFF
--- a/files/README-apt.txt
+++ b/files/README-apt.txt
@@ -1,15 +1,16 @@
-Puppet Labs Repositories
+Puppet, Inc. Apt Repositories
 
-For official documentation and setup instructions see:
-https://docs.puppet.com/puppet/latest/puppet_platform.html
+For official documentation and setup instructions, see:
+https://puppet.com/docs/puppet/latest/puppet_platform.html
 
-These repositories contain packages intended for public consumption. These packages contain software released by Puppet, Inc., e.g. Puppet, Puppet Server, PuppetDB, etc.
+These repositories contain packages intended for public consumption. These
+packages contain software released by Puppet, Inc., e.g. Puppet, Puppet Server,
+PuppetDB, etc.
 
-Please note the 'dependencies', 'devel', and 'main' repositories have been deprecated in favor of the 'puppet' and 'puppet5' repos.
 
-
-# To add the repo for your distribution, install the release package with the
-# codename for your distribution. For example, on xenial:
+## Installation
+To add the repo for your distribution, install the release package with the
+codename for your distribution. For example, on xenial:
 wget http://apt.puppetlabs.com/puppet-release-xenial.deb;
 sudo dpkg -i puppet-release-xenial.deb
 sudo apt-get update
@@ -27,8 +28,10 @@ rsync -a rsync://rsync.puppet.com/packages/apt /var/apt
 wget -r https://apt.puppetlabs.com
 
 
-## Archives
+## Nightlies
+Nightly repositories and packages can be found at nightlies.puppet.com/apt
 
+## Archives
 Older (> 3 years old) releases are regularly removed from this repository.
-Archives can be found in http://release-archives.puppet.com/apt
+Archives can be found at http://release-archives.puppet.com/apt
 

--- a/files/README-apt.txt
+++ b/files/README-apt.txt
@@ -1,0 +1,34 @@
+Puppet Labs Repositories
+
+For official documentation and setup instructions see:
+https://docs.puppet.com/puppet/latest/puppet_platform.html
+
+These repositories contain packages intended for public consumption. These packages contain software released by Puppet, Inc., e.g. Puppet, Puppet Server, PuppetDB, etc.
+
+Please note the 'dependencies', 'devel', and 'main' repositories have been deprecated in favor of the 'puppet' and 'puppet5' repos.
+
+
+# To add the repo for your distribution, install the release package with the
+# codename for your distribution. For example, on xenial:
+wget http://apt.puppetlabs.com/puppet-release-xenial.deb;
+sudo dpkg -i puppet-release-xenial.deb
+sudo apt-get update
+
+
+## Recommendations for Mirroring
+
+# Directly from S3 (preferred option):
+aws s3 sync --exclude '*.html' s3://apt.puppetlabs.com /var/apt
+
+# Rsync:
+rsync -a rsync://rsync.puppet.com/packages/apt /var/apt
+
+# HTTPS via CloudFront (fastest outside of US):
+wget -r https://apt.puppetlabs.com
+
+
+## Archives
+
+Older (> 3 years old) releases are regularly removed from this repository.
+Archives can be found in http://release-archives.puppet.com/apt
+

--- a/files/README-downloads.txt
+++ b/files/README-downloads.txt
@@ -1,0 +1,27 @@
+The platform folders:
+/mac and /windows
+contain platform specific packages for all of Puppetlabs projects.
+
+The project folders:
+/facter, /hiera, /mcollective, /puppet, and /puppetdb
+contain TARBALLS of the respective projects.
+
+/enterprise
+contains source packages for our Enterprise products
+
+/training
+contains public resources for Professional Service's trainings.
+
+/nightly
+contains tarballs of some of our projects built during the night
+and is deprecated.
+
+
+Note: you can find deb and rpm packages at apt.puppetlabs.com and
+yum.puppetlabs.com respectively, gems used to be hosted in a /gems directory
+but we now publish gems, including rcs, to rubygems.org
+
+Archives:
+
+Older (> 3 years old) releases are regularly removed from this repository.
+Archives can be found in http://release-archives.puppet.com/downloads

--- a/files/README-downloads.txt
+++ b/files/README-downloads.txt
@@ -1,27 +1,29 @@
+Puppet, Inc. Non-Linux Packages
+
+For official documentation and setup instructions, see:
+https://puppet.com/docs/puppet/latest/puppet_platform.html
+
+## Layout
+
 The platform folders:
-/mac and /windows
-contain platform specific packages for all of Puppetlabs projects.
+/eos, /mac, /windows
+contain platform-specific packages for all Puppet, Inc. open-source projects.
 
 The project folders:
-/facter, /hiera, /mcollective, /puppet, and /puppetdb
-contain TARBALLS of the respective projects.
+/facter, /hiera, /mcollective, /puppet, /puppetdb, /razor-client, /razor-server
+contain tarballs and/or gems of the respective projects.
 
 /enterprise
-contains source packages for our Enterprise products
-
-/training
-contains public resources for Professional Service's trainings.
-
-/nightly
-contains tarballs of some of our projects built during the night
-and is deprecated.
+contains source packages for third-party dependencies in Puppet Enterprise.
 
 
-Note: you can find deb and rpm packages at apt.puppetlabs.com and
-yum.puppetlabs.com respectively, gems used to be hosted in a /gems directory
-but we now publish gems, including rcs, to rubygems.org
+## Linux
+Deb and rpm packages can be found at apt.puppet.com and yum.puppet.com,
+respectively.
 
-Archives:
+## Nightlies
+Nightly packages can be found at nightlies.puppet.com/downloads
 
+## Archives
 Older (> 3 years old) releases are regularly removed from this repository.
-Archives can be found in http://release-archives.puppet.com/downloads
+Archives can be found at http://release-archives.puppet.com/downloads

--- a/files/README-yum.txt
+++ b/files/README-yum.txt
@@ -1,19 +1,17 @@
-Puppet Labs Repositories
+Puppet, Inc. Yum Repositories
 
-For official documentation and setup instructions see:
-https://docs.puppet.com/puppet/latest/puppet_platform.html
+For official documentation and setup instructions, see:
+https://puppet.com/docs/puppet/latest/puppet_platform.html
 
-These repositories contains packages intended for public consumption. These
+These repositories contain packages intended for public consumption. These
 packages are for software released by Puppet, Inc., e.g. Puppet, Puppet Server,
 PuppetDB, etc.
 
-Note that the 'dependencies', 'devel', and 'products' repositories have been
-deprecated in favor of the 'puppet' and 'puppet5' repos.
 
-
-# To add the repo for your distribution, install the release package with the
-# version for your distribution. For example, on centos 7:
-sudo rpm -Uvh http://yum.puppetlabs.com/puppet/puppet-release-el-7.noarch.rpm
+## Installation
+To add the repo for your distribution, install the release package with the
+version for your distribution. For example, on centos 7:
+sudo rpm -Uvh http://yum.puppetlabs.com/puppet-release-el-7.noarch.rpm
 
 
 ## Recommendations for Mirroring
@@ -28,8 +26,10 @@ rsync -a rsync://rsync.puppet.com/packages/yum /var/yum
 wget -r https://yum.puppetlabs.com
 
 
-## Archives
+## Nightlies
+Nightly repositories and packages can be found at nightlies.puppet.com/yum
 
+## Archives
 Older (> 3 years old) releases are regularly removed from this repository.
-Archives can be found in http://release-archives.puppet.com/yum
+Archives can be found at http://release-archives.puppet.com/yum
 

--- a/files/README-yum.txt
+++ b/files/README-yum.txt
@@ -1,0 +1,35 @@
+Puppet Labs Repositories
+
+For official documentation and setup instructions see:
+https://docs.puppet.com/puppet/latest/puppet_platform.html
+
+These repositories contains packages intended for public consumption. These
+packages are for software released by Puppet, Inc., e.g. Puppet, Puppet Server,
+PuppetDB, etc.
+
+Note that the 'dependencies', 'devel', and 'products' repositories have been
+deprecated in favor of the 'puppet' and 'puppet5' repos.
+
+
+# To add the repo for your distribution, install the release package with the
+# version for your distribution. For example, on centos 7:
+sudo rpm -Uvh http://yum.puppetlabs.com/puppet/puppet-release-el-7.noarch.rpm
+
+
+## Recommendations for Mirroring
+
+# Directly from S3 (preferred option):
+aws s3 sync --exclude '*.html' s3://yum.puppetlabs.com /var/yum
+
+# Rsync:
+rsync -a rsync://rsync.puppet.com/packages/yum /var/yum
+
+# HTTPS via CloudFront (fastest outside of US):
+wget -r https://yum.puppetlabs.com
+
+
+## Archives
+
+Older (> 3 years old) releases are regularly removed from this repository.
+Archives can be found in http://release-archives.puppet.com/yum
+


### PR DESCRIPTION
First commit is what's currently on yum/apt/downloads.
Second commit makes changes.

There are also a handful of additional READMEs on downloads.puppet.com that I didn't copy over to here. Not sure if we want to keep those or not.