### PR TITLE
(RE-12316) Add READMEs for nightlies

### DIFF
--- a/files/README-apt.txt
+++ b/files/README-apt.txt
@@ -3,6 +3,9 @@ Puppet, Inc. Apt Repositories
 For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
+For help, please open a ticket in the CPR project at https://tickets.puppet.com
+or reach out to us on Slack at http://slack.puppet.com/.
+
 These repositories contain packages intended for public consumption. These
 packages contain software released by Puppet, Inc., e.g. Puppet, Puppet Server,
 PuppetDB, etc.

--- a/files/README-downloads.txt
+++ b/files/README-downloads.txt
@@ -3,6 +3,9 @@ Puppet, Inc. Non-Linux Packages
 For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
+For help, please open a ticket in the CPR project at https://tickets.puppet.com
+or reach out to us on Slack at http://slack.puppet.com/.
+
 ## Layout
 
 The platform folders:

--- a/files/README-nightlies-apt.txt
+++ b/files/README-nightlies-apt.txt
@@ -3,6 +3,9 @@ Puppet, Inc. Nightly Apt Repositories
 For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
+For help, please open a ticket in the CPR project at https://tickets.puppet.com
+or reach out to us on Slack at http://slack.puppet.com/.
+
 These repositories contain *UNSUPPORTED* packages intended for public
 consumption. These packages contain software released by Puppet, Inc., e.g.
 Puppet, Puppet Server, PuppetDB, etc.

--- a/files/README-nightlies-apt.txt
+++ b/files/README-nightlies-apt.txt
@@ -1,0 +1,30 @@
+Puppet, Inc. Nightly Apt Repositories
+
+For official documentation and setup instructions, see:
+https://puppet.com/docs/puppet/latest/puppet_platform.html
+
+These repositories contain *UNSUPPORTED* packages intended for public
+consumption. These packages contain software released by Puppet, Inc., e.g.
+Puppet, Puppet Server, PuppetDB, etc.
+
+
+## Installation
+To add the repo for your distribution, install the release package with the
+codename for your distribution. For example, on xenial:
+wget http://nightlies.puppet.com/apt/puppet-nightly-release-xenial.deb;
+sudo dpkg -i puppet-nightly-release-xenial.deb
+sudo apt-get update
+
+
+## Recommendations for Mirroring
+
+# Directly from S3 (preferred option):
+aws s3 sync --exclude '*.html' s3://nightlies.puppet.com/apt /var/apt
+
+# HTTPS via CloudFront (fastest outside of US):
+wget -r https://nightlies.puppet.com/apt
+
+
+## Retention Policy
+Packages are removed from this repository after 30 days, unless there is only
+one remaining package for a given project.

--- a/files/README-nightlies-downloads.txt
+++ b/files/README-nightlies-downloads.txt
@@ -3,6 +3,9 @@ Puppet, Inc. Nightly Non-Linux Packages
 For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
+For help, please open a ticket in the CPR project at https://tickets.puppet.com
+or reach out to us on Slack at http://slack.puppet.com/.
+
 ## Layout
 The platform folders:
 /eos, /mac, /windows

--- a/files/README-nightlies-downloads.txt
+++ b/files/README-nightlies-downloads.txt
@@ -1,0 +1,20 @@
+Puppet, Inc. Nightly Non-Linux Packages
+
+For official documentation and setup instructions, see:
+https://puppet.com/docs/puppet/latest/puppet_platform.html
+
+## Layout
+The platform folders:
+/eos, /mac, /windows
+contain unreleased, platform-specific packages for Puppet, Inc. open-source
+projects.
+
+
+## Linux
+Deb and rpm packages can be found at nightlies.puppet.com/apt and
+nightlies.puppet.com/yum, respectively.
+
+
+## Retention Policy
+Packages are removed after 30 days, unless there is only one remaining package
+for a given project.

--- a/files/README-nightlies-yum.txt
+++ b/files/README-nightlies-yum.txt
@@ -3,6 +3,9 @@ Puppet, Inc. Nightly Yum Repositories
 For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
+For help, please open a ticket in the CPR project at https://tickets.puppet.com
+or reach out to us on Slack at http://slack.puppet.com/.
+
 These repositories contain *UNSUPPORTED* packages intended for public
 consumption. These packages contain unreleased software by Puppet, Inc., e.g.
 Puppet, Puppet Server, PuppetDB, etc.

--- a/files/README-nightlies-yum.txt
+++ b/files/README-nightlies-yum.txt
@@ -1,0 +1,28 @@
+Puppet, Inc. Nightly Yum Repositories
+
+For official documentation and setup instructions, see:
+https://puppet.com/docs/puppet/latest/puppet_platform.html
+
+These repositories contain *UNSUPPORTED* packages intended for public
+consumption. These packages contain unreleased software by Puppet, Inc., e.g.
+Puppet, Puppet Server, PuppetDB, etc.
+
+
+## Installation
+To add the repo for your distribution, install the release package with the
+version for your distribution. For example, on centos 7:
+sudo rpm -Uvh http://nightlies.puppet.com/yum/puppet-nightly-release-el-7.noarch.rpm
+
+
+## Recommendations for Mirroring
+
+# Directly from S3 (preferred option):
+aws s3 sync --exclude '*.html' s3://nightlies.puppet.com/yum /var/yum
+
+# HTTPS via CloudFront (fastest outside of US):
+wget -r https://nightlies.puppet.com/yum
+
+
+## Retention Policy
+Packages are removed from this repository after 30 days, unless there is only
+one remaining package for a given project.

--- a/files/README-nightlies.txt
+++ b/files/README-nightlies.txt
@@ -1,0 +1,11 @@
+Puppet, Inc. Nightly Packages
+
+These repositories contain *UNSUPPORTED* packages intended for public
+consumption. These packages contain unreleased software by Puppet, Inc., e.g.
+Puppet, Puppet Server, PuppetDB, etc.
+
+For rpm packages, visit nightlies.puppet.com/yum
+For deb packages, visit nightlies.puppet.com/apt
+For other package types, visit nightlies.puppet.com/downloads
+
+For released software, visit yum.puppet.com, apt.puppet.com, or downloads.puppet.com

--- a/files/README-yum.txt
+++ b/files/README-yum.txt
@@ -3,6 +3,9 @@ Puppet, Inc. Yum Repositories
 For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
+For help, please open a ticket in the CPR project at https://tickets.puppet.com
+or reach out to us on Slack at http://slack.puppet.com/.
+
 These repositories contain packages intended for public consumption. These
 packages are for software released by Puppet, Inc., e.g. Puppet, Puppet Server,
 PuppetDB, etc.


### PR DESCRIPTION
This commit adds READMEs for the top level of nightlies.puppet.com as well as
the yum, apt, and downloads subdirectories.