### PR TITLE
(CPR-658) Remove source repositories

### DIFF
--- a/files/puppet-nightly.list.txt
+++ b/files/puppet-nightly.list.txt
@@ -1,9 +1,2 @@
 # Puppet Nightly __CODENAME__ Repository
 deb http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly
-
-# Puppet Nightly __CODENAME__ Source Repository
-# The source repos are commented out by default because we
-# do not always make sources available for all packages or
-# for all platforms. If you want to access the source repos,
-# uncomment the following line.
-#deb-src http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly

--- a/files/puppet-nightly.repo.txt
+++ b/files/puppet-nightly.repo.txt
@@ -4,11 +4,3 @@ baseurl=http://nightlies.puppet.com/yum/puppet-nightly/__OS_NAME__/__OS_VERSION_
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-nightly-release
 enabled=1
 gpgcheck=1
-
-[puppet-nightly-source]
-name=Puppet Nightly Repository __OS_NAME__ __OS_VERSION__ - Source
-baseurl=http://nightlies.puppet.com/yum/puppet-nightly/__OS_NAME__/__OS_VERSION__/SRPMS
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-nightly-release
-failovermethod=priority
-enabled=0
-gpgcheck=1

--- a/files/puppet.list.txt
+++ b/files/puppet.list.txt
@@ -1,9 +1,2 @@
 # Puppet __CODENAME__ Repository
 deb http://apt.puppetlabs.com __CODENAME__ puppet
-
-# Puppet __CODENAME__ Source Repository
-# The source repos are commented out by default because we
-# do not always make sources available for all packages or
-# for all platforms. If you want to access the source repos,
-# uncomment the following line.
-#deb-src http://apt.puppetlabs.com __CODENAME__ puppet

--- a/files/puppet.repo.txt
+++ b/files/puppet.repo.txt
@@ -4,11 +4,3 @@ baseurl=http://yum.puppetlabs.com/puppet/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-release
 enabled=1
 gpgcheck=1
-
-[puppet-source]
-name=Puppet Repository __OS_NAME__ __OS_VERSION__ - Source
-baseurl=http://yum.puppetlabs.com/puppet/__OS_NAME__/__OS_VERSION__/SRPMS
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-release
-failovermethod=priority
-enabled=0
-gpgcheck=1

--- a/files/puppet5-nightly.list.txt
+++ b/files/puppet5-nightly.list.txt
@@ -1,9 +1,2 @@
 # Puppet 5 Nightly __CODENAME__ Repository
 deb http://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly
-
-# Puppet 5 Nightly __CODENAME__ Source Repository
-# The source repos are commented out by default because we
-# do not always make sources available for all packages or
-# for all platforms. If you want to access the source repos,
-# uncomment the following line.
-#deb-src http://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly

--- a/files/puppet5-nightly.repo.txt
+++ b/files/puppet5-nightly.repo.txt
@@ -4,11 +4,3 @@ baseurl=http://nightlies.puppet.com/yum/puppet5-nightly/__OS_NAME__/__OS_VERSION
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-nightly-release
 enabled=1
 gpgcheck=1
-
-[puppet5-nightly-source]
-name=Puppet 5 Nightly Repository __OS_NAME__ __OS_VERSION__ - Source
-baseurl=http://nightlies.puppet.com/yum/puppet5-nightly/__OS_NAME__/__OS_VERSION__/SRPMS
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-nightly-release
-failovermethod=priority
-enabled=0
-gpgcheck=1

--- a/files/puppet6-nightly.list.txt
+++ b/files/puppet6-nightly.list.txt
@@ -1,9 +1,2 @@
 # Puppet 6 Nightly __CODENAME__ Repository
 deb http://nightlies.puppet.com/apt __CODENAME__ puppet6-nightly
-
-# Puppet 6 Nightly __CODENAME__ Source Repository
-# The source repos are commented out by default because we
-# do not always make sources available for all packages or
-# for all platforms. If you want to access the source repos,
-# uncomment the following line.
-#deb-src http://nightlies.puppet.com/apt __CODENAME__ puppet6-nightly

--- a/files/puppet6-nightly.repo.txt
+++ b/files/puppet6-nightly.repo.txt
@@ -4,11 +4,3 @@ baseurl=http://nightlies.puppet.com/yum/puppet6-nightly/__OS_NAME__/__OS_VERSION
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-nightly-release
 enabled=1
 gpgcheck=1
-
-[puppet6-nightly-source]
-name=Puppet 6 Nightly Repository __OS_NAME__ __OS_VERSION__ - Source
-baseurl=http://nightlies.puppet.com/yum/puppet6-nightly/__OS_NAME__/__OS_VERSION__/SRPMS
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-nightly-release
-failovermethod=priority
-enabled=0
-gpgcheck=1

--- a/files/puppet6.list.txt
+++ b/files/puppet6.list.txt
@@ -1,9 +1,2 @@
 # Puppet 6 __CODENAME__ Repository
 deb http://apt.puppetlabs.com __CODENAME__ puppet6
-
-# Puppet 6 __CODENAME__ Source Repository
-# The source repos are commented out by default because we
-# do not always make sources available for all packages or
-# for all platforms. If you want to access the source repos,
-# uncomment the following line.
-#deb-src http://apt.puppetlabs.com __CODENAME__ puppet6

--- a/files/puppet6.repo.txt
+++ b/files/puppet6.repo.txt
@@ -4,11 +4,3 @@ baseurl=http://yum.puppetlabs.com/puppet6/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-release
 enabled=1
 gpgcheck=1
-
-[puppet6-source]
-name=Puppet 6 Repository __OS_NAME__ __OS_VERSION__ - Source
-baseurl=http://yum.puppetlabs.com/puppet6/__OS_NAME__/__OS_VERSION__/SRPMS
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-release
-failovermethod=priority
-enabled=0
-gpgcheck=1


### PR DESCRIPTION
This commit removes the yum source repositories from the puppet5-nightly,
puppet6-nightly, puppet-nightly, puppet6, and puppet repo configs. We have not
made source packages available in these repos, so there's no need for them in
the configs.