### PR TITLE
(RE-12521) Rename puppet-enterprise-tools repo to puppet-tools

### DIFF
--- a/configs/projects/puppet-tools-release.rb
+++ b/configs/projects/puppet-tools-release.rb
@@ -1,18 +1,20 @@
-project 'puppet-enterprise-tools-release' do |proj|
-  proj.description 'Release packages for the puppet-enterprise-tools repository'
+project 'puppet-tools-release' do |proj|
+  proj.description 'Release packages for the puppet-tools repository'
   proj.release '1'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'
   proj.homepage 'https://www.puppet.com'
-  proj.target_repo 'puppet-enterprise-tools'
+  proj.target_repo 'puppet-tools'
   proj.noarch
 
-  proj.setting(:target_repo, 'puppet-enterprise-tools')
+  proj.setting(:target_repo, 'puppet-tools')
 
   proj.conflicts 'puppet-release'
   proj.conflicts 'puppet5-release'
   proj.conflicts 'puppet6-release'
+  proj.conflicts 'puppet-enterprise-tools-release'
+  proj.replaces 'puppet-enterprise-tools-release'
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'

--- a/files/puppet-enterprise-tools.list.txt
+++ b/files/puppet-enterprise-tools.list.txt
@@ -1,2 +1,0 @@
-# Puppet Enterprise Tools __CODENAME__ Repository
-deb http://apt.puppet.com __CODENAME__ puppet-enterprise-tools

--- a/files/puppet-enterprise-tools.repo.txt
+++ b/files/puppet-enterprise-tools.repo.txt
@@ -1,6 +1,0 @@
-[puppet-enterprise-tools]
-name=Puppet Enterprise Tools Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://yum.puppet.com/puppet-enterprise-tools/__OS_NAME__/__OS_VERSION__/$basearch
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-enterprise-tools-release
-enabled=1
-gpgcheck=1

--- a/files/puppet-tools.list.txt
+++ b/files/puppet-tools.list.txt
@@ -1,0 +1,2 @@
+# Puppet Tools __CODENAME__ Repository
+deb http://apt.puppet.com __CODENAME__ puppet-tools

--- a/files/puppet-tools.repo.txt
+++ b/files/puppet-tools.repo.txt
@@ -1,0 +1,6 @@
+[puppet-tools]
+name=Puppet Tools Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://yum.puppet.com/puppet-tools/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-tools-release
+enabled=1
+gpgcheck=1


### PR DESCRIPTION
This commit renames the puppet-enterprise-tools package repository to
puppet-tools. This allows us to point both FOSS and PE users to the same set
of installation instructions for non-Puppet-Platform products like Bolt.