### PR TITLE
(RE-12490) Fix SLES gpgkey handling

### DIFF
--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -38,7 +38,7 @@ component 'repo_definition' do |pkg, settings, platform|
     # a '='. This isn't the case for other rpm platforms, so we get to modify
     # the repo file after we install it on sles.
     if platform.is_sles?
-      install_hash << "sed -i -e 's|file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet|=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet|g' #{repo_path}/puppetlabs-pc1.repo"
+      install_hash << "sed -i -e 's|[^=]file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet|=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet|g' #{repo_path}/puppetlabs-pc1.repo"
     end
 
     pkg.install do
@@ -46,4 +46,3 @@ component 'repo_definition' do |pkg, settings, platform|
     end
   end
 end
-

--- a/configs/projects/puppet-archives-release.rb
+++ b/configs/projects/puppet-archives-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-archives-release' do |proj|
   proj.description 'Release packages for the end-of-life Puppet repository'
-  proj.release '2'
+  proj.release '3'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/configs/projects/puppetlabs-release-pc1.rb
+++ b/configs/projects/puppetlabs-release-pc1.rb
@@ -1,6 +1,6 @@
 project 'puppetlabs-release-pc1' do |proj|
   proj.description 'Release packages for the end-of-life Puppet Labs PC1 repository'
-  proj.release '1'
+  proj.release '2'
   proj.license 'ASL 2.0'
   proj.version '2.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'


### PR DESCRIPTION
On SLES, there must be an '=' before the file:/// URL for gpgkey.
However, there can only be one, otherwise zypper is unhappy.

This change will prepend a '=' to the gpgkey 'file:///' path
on SLES but only if one does not yet exist.

I tested the sed logic locally but not sure what other testing we
do (or if there's any other file updates needed) to verify.