### PR TITLE
(CPR-517) Use https as much as possible

### DIFF
--- a/configs/platforms/cisco-wrlinux-5-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-5-x86_64.rb
@@ -3,7 +3,7 @@ platform "cisco-wrlinux-5-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/cisco-wrlinux/5/pl-build-tools-cisco-wrlinux-5.repo"
+  plat.yum_repo "https://pl-build-tools.delivery.puppetlabs.net/yum/cisco-wrlinux/5/pl-build-tools-cisco-wrlinux-5.repo"
   plat.provision_with "yum install -y autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils;yum update -y pkgconfig"
   plat.install_build_dependencies_with "yum install -y"
   plat.vmpooler_template "cisco-wrlinux-5-x86_64"

--- a/configs/platforms/cisco-wrlinux-7-x86_64.rb
+++ b/configs/platforms/cisco-wrlinux-7-x86_64.rb
@@ -4,7 +4,7 @@ platform "cisco-wrlinux-7-x86_64" do |plat|
   plat.servicetype "sysv"
   # The development environment provided by Cisco includes the build dependencies
   # such as autoconf automake createrepo rsync gcc make rpm-build rpm-libs yum-utils
-  plat.yum_repo "http://pl-build-tools.delivery.puppetlabs.net/yum/cisco-wrlinux/7/pl-build-tools-cisco-wrlinux-7.repo"
+  plat.yum_repo "https://pl-build-tools.delivery.puppetlabs.net/yum/cisco-wrlinux/7/pl-build-tools-cisco-wrlinux-7.repo"
   plat.install_build_dependencies_with "yum install -y"
   plat.vmpooler_template "cisco-wrlinux-7-x86_64"
 end

--- a/configs/platforms/el-5-x86_64.rb
+++ b/configs/platforms/el-5-x86_64.rb
@@ -3,7 +3,7 @@ platform "el-5-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=http://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch\ngpgcheck=0' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/5/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
+  plat.provision_with "yum install -y --nogpgcheck autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign rpm-build; echo '[build-tools]\nname=build-tools\nbaseurl=https://enterprise.delivery.puppetlabs.net/build-tools/el/5/$basearch\ngpgcheck=0' > /etc/yum.repos.d/build-tools.repo;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=https://pl-build-tools.delivery.puppetlabs.net/yum/el/5/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install -y --nogpgcheck"
   plat.vmpooler_template "centos-5-x86_64"
 end

--- a/configs/platforms/el-6-x86_64.rb
+++ b/configs/platforms/el-6-x86_64.rb
@@ -3,7 +3,7 @@ platform "el-6-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "sysv"
 
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=https://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "centos-6-x86_64"
 end

--- a/configs/platforms/el-7-x86_64.rb
+++ b/configs/platforms/el-7-x86_64.rb
@@ -3,7 +3,7 @@ platform "el-7-x86_64" do |plat|
   plat.defaultdir "/etc/sysconfig"
   plat.servicetype "systemd"
 
-  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
+  plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign;echo '[pl-build-tools]\nname=pl-build-tools\ngpgcheck=0\nbaseurl=https://pl-build-tools.delivery.puppetlabs.net/yum/el/6/$basearch' > /etc/yum.repos.d/pl-build-tools.repo"
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "centos-7-x86_64"
 end

--- a/files/README-apt.txt
+++ b/files/README-apt.txt
@@ -4,7 +4,7 @@ For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
 For help, please open a ticket in the CPR project at https://tickets.puppet.com
-or reach out to us on Slack at http://slack.puppet.com/.
+or reach out to us on Slack at https://slack.puppet.com/.
 
 These repositories contain packages intended for public consumption. These
 packages contain software released by Puppet, Inc., e.g. Puppet, Puppet Server,
@@ -14,7 +14,7 @@ PuppetDB, etc.
 ## Installation
 To add the repo for your distribution, install the release package with the
 codename for your distribution. For example, on xenial:
-wget http://apt.puppetlabs.com/puppet-release-xenial.deb;
+wget https://apt.puppetlabs.com/puppet-release-xenial.deb;
 sudo dpkg -i puppet-release-xenial.deb
 sudo apt-get update
 
@@ -37,4 +37,3 @@ Nightly repositories and packages can be found at nightlies.puppet.com/apt
 ## Archives
 Older (> 3 years old) releases are regularly removed from this repository.
 Archives can be found at http://release-archives.puppet.com/apt
-

--- a/files/README-downloads.txt
+++ b/files/README-downloads.txt
@@ -4,7 +4,7 @@ For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
 For help, please open a ticket in the CPR project at https://tickets.puppet.com
-or reach out to us on Slack at http://slack.puppet.com/.
+or reach out to us on Slack at https://slack.puppet.com/.
 
 ## Layout
 

--- a/files/README-nightlies-apt.txt
+++ b/files/README-nightlies-apt.txt
@@ -4,7 +4,7 @@ For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
 For help, please open a ticket in the CPR project at https://tickets.puppet.com
-or reach out to us on Slack at http://slack.puppet.com/.
+or reach out to us on Slack at https://slack.puppet.com/.
 
 These repositories contain *UNSUPPORTED* packages intended for public
 consumption. These packages contain software released by Puppet, Inc., e.g.
@@ -14,7 +14,7 @@ Puppet, Puppet Server, PuppetDB, etc.
 ## Installation
 To add the repo for your distribution, install the release package with the
 codename for your distribution. For example, on xenial:
-wget http://nightlies.puppet.com/apt/puppet-nightly-release-xenial.deb;
+wget https://nightlies.puppet.com/apt/puppet-nightly-release-xenial.deb;
 sudo dpkg -i puppet-nightly-release-xenial.deb
 sudo apt-get update
 

--- a/files/README-nightlies-downloads.txt
+++ b/files/README-nightlies-downloads.txt
@@ -4,7 +4,7 @@ For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
 For help, please open a ticket in the CPR project at https://tickets.puppet.com
-or reach out to us on Slack at http://slack.puppet.com/.
+or reach out to us on Slack at https://slack.puppet.com/.
 
 ## Layout
 The platform folders:

--- a/files/README-nightlies-yum.txt
+++ b/files/README-nightlies-yum.txt
@@ -4,7 +4,7 @@ For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
 For help, please open a ticket in the CPR project at https://tickets.puppet.com
-or reach out to us on Slack at http://slack.puppet.com/.
+or reach out to us on Slack at https://slack.puppet.com/.
 
 These repositories contain *UNSUPPORTED* packages intended for public
 consumption. These packages contain unreleased software by Puppet, Inc., e.g.
@@ -14,7 +14,7 @@ Puppet, Puppet Server, PuppetDB, etc.
 ## Installation
 To add the repo for your distribution, install the release package with the
 version for your distribution. For example, on centos 7:
-sudo rpm -Uvh http://nightlies.puppet.com/yum/puppet-nightly-release-el-7.noarch.rpm
+sudo rpm -Uvh https://nightlies.puppet.com/yum/puppet-nightly-release-el-7.noarch.rpm
 
 
 ## Recommendations for Mirroring

--- a/files/README-yum.txt
+++ b/files/README-yum.txt
@@ -4,7 +4,7 @@ For official documentation and setup instructions, see:
 https://puppet.com/docs/puppet/latest/puppet_platform.html
 
 For help, please open a ticket in the CPR project at https://tickets.puppet.com
-or reach out to us on Slack at http://slack.puppet.com/.
+or reach out to us on Slack at https://slack.puppet.com/.
 
 These repositories contain packages intended for public consumption. These
 packages are for software released by Puppet, Inc., e.g. Puppet, Puppet Server,
@@ -14,7 +14,7 @@ PuppetDB, etc.
 ## Installation
 To add the repo for your distribution, install the release package with the
 version for your distribution. For example, on centos 7:
-sudo rpm -Uvh http://yum.puppetlabs.com/puppet-release-el-7.noarch.rpm
+sudo rpm -Uvh https://yum.puppetlabs.com/puppet-release-el-7.noarch.rpm
 
 
 ## Recommendations for Mirroring
@@ -35,4 +35,3 @@ Nightly repositories and packages can be found at nightlies.puppet.com/yum
 ## Archives
 Older (> 3 years old) releases are regularly removed from this repository.
 Archives can be found at http://release-archives.puppet.com/yum
-

--- a/files/puppet-nightly.list.txt
+++ b/files/puppet-nightly.list.txt
@@ -1,2 +1,2 @@
 # Puppet Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly
+deb https://nightlies.puppet.com/apt __CODENAME__ puppet-nightly

--- a/files/puppet-nightly.repo.txt
+++ b/files/puppet-nightly.repo.txt
@@ -1,6 +1,6 @@
 [puppet-nightly]
 name=Puppet Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://nightlies.puppet.com/yum/puppet-nightly/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://nightlies.puppet.com/yum/puppet-nightly/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-nightly-release
 enabled=1
 gpgcheck=1

--- a/files/puppet-tools.list.txt
+++ b/files/puppet-tools.list.txt
@@ -1,2 +1,2 @@
 # Puppet Tools __CODENAME__ Repository
-deb http://apt.puppet.com __CODENAME__ puppet-tools
+deb https://apt.puppet.com __CODENAME__ puppet-tools

--- a/files/puppet-tools.repo.txt
+++ b/files/puppet-tools.repo.txt
@@ -1,6 +1,6 @@
 [puppet-tools]
 name=Puppet Tools Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://yum.puppet.com/puppet-tools/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.puppet.com/puppet-tools/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-tools-release
 enabled=1
 gpgcheck=1

--- a/files/puppet.list.txt
+++ b/files/puppet.list.txt
@@ -1,2 +1,2 @@
 # Puppet __CODENAME__ Repository
-deb http://apt.puppetlabs.com __CODENAME__ puppet
+deb https://apt.puppetlabs.com __CODENAME__ puppet

--- a/files/puppet.repo.txt
+++ b/files/puppet.repo.txt
@@ -1,6 +1,6 @@
 [puppet]
 name=Puppet Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://yum.puppetlabs.com/puppet/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.puppetlabs.com/puppet/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-release
 enabled=1
 gpgcheck=1

--- a/files/puppet5-nightly.list.txt
+++ b/files/puppet5-nightly.list.txt
@@ -1,2 +1,2 @@
 # Puppet 5 Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly
+deb https://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly

--- a/files/puppet5-nightly.repo.txt
+++ b/files/puppet5-nightly.repo.txt
@@ -1,6 +1,6 @@
 [puppet5-nightly]
 name=Puppet 5 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://nightlies.puppet.com/yum/puppet5-nightly/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://nightlies.puppet.com/yum/puppet5-nightly/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-nightly-release
 enabled=1
 gpgcheck=1

--- a/files/puppet5.list.txt
+++ b/files/puppet5.list.txt
@@ -1,9 +1,9 @@
 # Puppet 5 __CODENAME__ Repository
-deb http://apt.puppetlabs.com __CODENAME__ puppet5
+deb https://apt.puppetlabs.com __CODENAME__ puppet5
 
 # Puppet 5 __CODENAME__ Source Repository
 # The source repos are commented out by default because we
 # do not always make sources available for all packages or
 # for all platforms. If you want to access the source repos,
 # uncomment the following line.
-#deb-src http://apt.puppetlabs.com __CODENAME__ puppet5
+#deb-src https://apt.puppetlabs.com __CODENAME__ puppet5

--- a/files/puppet5.repo.txt
+++ b/files/puppet5.repo.txt
@@ -1,13 +1,13 @@
 [puppet5]
 name=Puppet 5 Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://yum.puppetlabs.com/puppet5/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.puppetlabs.com/puppet5/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
 enabled=1
 gpgcheck=1
 
 [puppet5-source]
 name=Puppet 5 Repository __OS_NAME__ __OS_VERSION__ - Source
-baseurl=http://yum.puppetlabs.com/puppet5-nightly/__OS_NAME__/__OS_VERSION__/SRPMS
+baseurl=https://yum.puppetlabs.com/puppet5-nightly/__OS_NAME__/__OS_VERSION__/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
 failovermethod=priority
 enabled=0

--- a/files/puppet6-nightly.list.txt
+++ b/files/puppet6-nightly.list.txt
@@ -1,2 +1,2 @@
 # Puppet 6 Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet6-nightly
+deb https://nightlies.puppet.com/apt __CODENAME__ puppet6-nightly

--- a/files/puppet6-nightly.repo.txt
+++ b/files/puppet6-nightly.repo.txt
@@ -1,6 +1,6 @@
 [puppet6-nightly]
 name=Puppet 6 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://nightlies.puppet.com/yum/puppet6-nightly/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://nightlies.puppet.com/yum/puppet6-nightly/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-nightly-release
 enabled=1
 gpgcheck=1

--- a/files/puppet6.list.txt
+++ b/files/puppet6.list.txt
@@ -1,2 +1,2 @@
 # Puppet 6 __CODENAME__ Repository
-deb http://apt.puppetlabs.com __CODENAME__ puppet6
+deb https://apt.puppetlabs.com __CODENAME__ puppet6

--- a/files/puppet6.repo.txt
+++ b/files/puppet6.repo.txt
@@ -1,6 +1,6 @@
 [puppet6]
 name=Puppet 6 Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://yum.puppetlabs.com/puppet6/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.puppetlabs.com/puppet6/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-release
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
Find cases inside our release packages and documentation that use
'http:'; switch them to use 'https:'

Test each one by grepping each of the URLs and verifying that
they resolve.