### PR TITLE
(CPR-736) fix puppet5.repo file to not include "nightly"

### DIFF
--- a/configs/projects/puppet5-release.rb
+++ b/configs/projects/puppet5-release.rb
@@ -1,6 +1,6 @@
 project 'puppet5-release' do |proj|
   proj.description 'Release packages for the Puppet5 repository'
-  proj.release '8'
+  proj.release '9'
   proj.license 'ASL 2.0'
   proj.version '5.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/files/puppet5.repo.txt
+++ b/files/puppet5.repo.txt
@@ -7,7 +7,7 @@ gpgcheck=1
 
 [puppet5-source]
 name=Puppet 5 Repository __OS_NAME__ __OS_VERSION__ - Source
-baseurl=https://yum.puppetlabs.com/puppet5-nightly/__OS_NAME__/__OS_VERSION__/SRPMS
+baseurl=https://yum.puppetlabs.com/puppet5/__OS_NAME__/__OS_VERSION__/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
 failovermethod=priority
 enabled=0


### PR DESCRIPTION
i think at some point this file was copied over incorrectly to include nightly
which was causing the source rpm to point to the wrong thing