### PR TITLE
(maint) handle apt transport method

### DIFF
--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -7,6 +7,14 @@ component 'repo_definition' do |pkg, settings, platform|
     pkg.install do
       "sed -i 's|__CODENAME__|#{platform.codename}|g' /etc/apt/sources.list.d/#{settings[:target_repo]}.list"
     end
+    pkg.add_postinstall_action ["install"],
+      [<<-HERE.undent
+          if [ ! -e /usr/lib/apt/methods/https ]; then
+            sed -i -e 's|https://|http://|' /etc/apt/sources.list.d/#{settings[:target_repo]}.list
+          fi
+        HERE
+      ]
+
   else
     # Specifying the repo path as a platform config var is likely the
     # way to go if anything else needs to get added here:

--- a/files/README-apt.txt
+++ b/files/README-apt.txt
@@ -14,7 +14,7 @@ PuppetDB, etc.
 ## Installation
 To add the repo for your distribution, install the release package with the
 codename for your distribution. For example, on xenial:
-wget http://apt.puppetlabs.com/puppet-release-xenial.deb;
+wget https://apt.puppetlabs.com/puppet-release-xenial.deb;
 sudo dpkg -i puppet-release-xenial.deb
 sudo apt-get update
 

--- a/files/README-nightlies-apt.txt
+++ b/files/README-nightlies-apt.txt
@@ -14,7 +14,7 @@ Puppet, Puppet Server, PuppetDB, etc.
 ## Installation
 To add the repo for your distribution, install the release package with the
 codename for your distribution. For example, on xenial:
-wget http://nightlies.puppet.com/apt/puppet-nightly-release-xenial.deb;
+wget https://nightlies.puppet.com/apt/puppet-nightly-release-xenial.deb;
 sudo dpkg -i puppet-nightly-release-xenial.deb
 sudo apt-get update
 

--- a/files/puppet-nightly.list.txt
+++ b/files/puppet-nightly.list.txt
@@ -1,2 +1,2 @@
 # Puppet Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly
+deb https://nightlies.puppet.com/apt __CODENAME__ puppet-nightly

--- a/files/puppet-tools.list.txt
+++ b/files/puppet-tools.list.txt
@@ -1,2 +1,2 @@
 # Puppet Tools __CODENAME__ Repository
-deb http://apt.puppet.com __CODENAME__ puppet-tools
+deb https://apt.puppet.com __CODENAME__ puppet-tools

--- a/files/puppet.list.txt
+++ b/files/puppet.list.txt
@@ -1,2 +1,2 @@
 # Puppet __CODENAME__ Repository
-deb http://apt.puppetlabs.com __CODENAME__ puppet
+deb https://apt.puppetlabs.com __CODENAME__ puppet

--- a/files/puppet5-nightly.list.txt
+++ b/files/puppet5-nightly.list.txt
@@ -1,2 +1,2 @@
 # Puppet 5 Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly
+deb https://nightlies.puppet.com/apt __CODENAME__ puppet5-nightly

--- a/files/puppet5.list.txt
+++ b/files/puppet5.list.txt
@@ -1,9 +1,9 @@
 # Puppet 5 __CODENAME__ Repository
-deb http://apt.puppetlabs.com __CODENAME__ puppet5
+deb https://apt.puppetlabs.com __CODENAME__ puppet5
 
 # Puppet 5 __CODENAME__ Source Repository
 # The source repos are commented out by default because we
 # do not always make sources available for all packages or
 # for all platforms. If you want to access the source repos,
 # uncomment the following line.
-#deb-src http://apt.puppetlabs.com __CODENAME__ puppet5
+#deb-src https://apt.puppetlabs.com __CODENAME__ puppet5

--- a/files/puppet6-nightly.list.txt
+++ b/files/puppet6-nightly.list.txt
@@ -1,2 +1,2 @@
 # Puppet 6 Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet6-nightly
+deb https://nightlies.puppet.com/apt __CODENAME__ puppet6-nightly

--- a/files/puppet6.list.txt
+++ b/files/puppet6.list.txt
@@ -1,2 +1,2 @@
 # Puppet 6 __CODENAME__ Repository
-deb http://apt.puppetlabs.com __CODENAME__ puppet6
+deb https://apt.puppetlabs.com __CODENAME__ puppet6


### PR DESCRIPTION
Since we changed apt to use https, there are various Debian flavors not supporting it yet. 
Specifically if apt is lower that 1.5 and apt-transport-https is not installed, https cannot be used.

This PR reverts the `Partial revert back to 'http' from 'https' for debian` and adds a postinstall script to replace https with http in puppet sources list if apt does not support https transport method