### PR TITLE
The Rakefile still had 'implode' warning. This is no longer needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 puppetlabs-release
 ==================
 
-Repo that builds packages to add our apt and yum repositories and public signing key. To see the latest changes, checkout the `puppet` branch.
+Repo for yum and apt release packages with Puppet's signing key.
+
+See "Build and Ship a Release Package" in Confluence
+(https://confluence.puppetlabs.com/pages/viewpage.action?pageId=159652513)
+for details.
 
 NOTE: We must now set the project using the `PROJECT_OVERRIDE` environment
-      variable when performing tasks with the packaging repo.
+variable when performing tasks with the packaging repo.

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,3 @@ require 'packaging'
 
 Pkg::Util::RakeUtils.load_packaging_tasks
 
-namespace :package do
-  task :bootstrap do
-    puts 'Bootstrap is no longer needed, using packaging-as-a-gem'
-  end
-  task :implode do
-    puts 'Implode is no longer needed, using packaging-as-a-gem'
-  end
-end


### PR DESCRIPTION
The README referred to a non-existent branch, which I removed.
Also, made reference to the confluence page with how-to instructions.

Ideally, the confluence doc should move into the README, but that's for another time.