### PR TITLE
(RE-13419) Add new key as secondary line for yum packages

### DIFF
--- a/configs/components/repo_definition.rb
+++ b/configs/components/repo_definition.rb
@@ -1,5 +1,5 @@
 component 'repo_definition' do |pkg, settings, platform|
-  pkg.version '2018.3.22'
+  pkg.version '2020.05.18'
 
   if platform.is_deb?
     pkg.url "file://files/#{settings[:target_repo]}.list.txt"

--- a/configs/projects/puppet5-release.rb
+++ b/configs/projects/puppet5-release.rb
@@ -1,6 +1,6 @@
 project 'puppet5-release' do |proj|
   proj.description 'Release packages for the Puppet5 repository'
-  proj.release '11'
+  proj.release '12'
   proj.license 'ASL 2.0'
   proj.version '5.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/configs/projects/puppet6-release.rb
+++ b/configs/projects/puppet6-release.rb
@@ -1,6 +1,6 @@
 project 'puppet6-release' do |proj|
   proj.description 'Release packages for the Puppet 6 repository'
-  proj.release '9'
+  proj.release '10'
   proj.license 'ASL 2.0'
   proj.version '6.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/files/puppet5.repo.txt
+++ b/files/puppet5.repo.txt
@@ -2,6 +2,7 @@
 name=Puppet 5 Repository __OS_NAME__ __OS_VERSION__ - $basearch
 baseurl=http://yum.puppetlabs.com/puppet5/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet5-release
 enabled=1
 gpgcheck=1
 
@@ -9,6 +10,7 @@ gpgcheck=1
 name=Puppet 5 Repository __OS_NAME__ __OS_VERSION__ - Source
 baseurl=http://yum.puppetlabs.com/puppet5/__OS_NAME__/__OS_VERSION__/SRPMS
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet5-release
 failovermethod=priority
 enabled=0
 gpgcheck=1

--- a/files/puppet6.repo.txt
+++ b/files/puppet6.repo.txt
@@ -2,5 +2,6 @@
 name=Puppet 6 Repository __OS_NAME__ __OS_VERSION__ - $basearch
 baseurl=http://yum.puppetlabs.com/puppet6/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet6-release
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
Yum packages allow for multiple GPG signing keys. Keep the old one
during the transition but add in the new one for future use.