### PR TITLE
(maint) update puppet-nightly.sles.txt files

### DIFF
--- a/files/puppet-nightly.sles.txt
+++ b/files/puppet-nightly.sles.txt
@@ -1,1 +1,1 @@
-puppet-nightly.list.txt
+puppet-nightly.repo.txt

--- a/files/puppet5-nightly.sles.txt
+++ b/files/puppet5-nightly.sles.txt
@@ -1,1 +1,1 @@
-puppet5-nightly.list.txt
+puppet5-nightly.repo.txt

--- a/files/puppet6-nightly.sles.txt
+++ b/files/puppet6-nightly.sles.txt
@@ -1,1 +1,1 @@
-puppet6-nightly.list.txt
+puppet6-nightly.repo.txt

--- a/files/puppet7-nightly.sles.txt
+++ b/files/puppet7-nightly.sles.txt
@@ -1,1 +1,1 @@
-puppet7-nightly.list.txt
+puppet7-nightly.repo.txt


### PR DESCRIPTION
The config files for sles where pointing to
puppet-nightly.list.txt which configure deb definitions.
Updated the symlinks to puppet-nightly.repo.txt
which contain rpm definitions.

This is causing the following error:
```
❯ zypper install puppet-agent
Unexpected exception.
/etc/zypp/repos.d/puppet7-nightly.repo: Section []: Line 2 contains garbage (no '=' or ',|/\' in key)
Please file a bug report about this.
See http://en.opensuse.org/Zypper/Troubleshooting for instructions.
❯ cat /etc/zypp/repos.d/puppet7-nightly.repo
# Puppet 7 Nightly __CODENAME__ Repository
deb http://nightlies.puppet.com/apt __CODENAME__ puppet7-nightly
```