### PR TITLE
(CPR-758) Build puppet-release for RedHat 8 aarch64

### DIFF
--- a/configs/platforms/el-8-aarch64.rb
+++ b/configs/platforms/el-8-aarch64.rb
@@ -1,0 +1,10 @@
+platform "el-8-aarch64" do |plat|
+    plat.servicedir "/usr/lib/systemd/system"
+    plat.defaultdir "/etc/sysconfig"
+    plat.servicetype "systemd"
+  
+    plat.provision_with "yum install --assumeyes autoconf automake createrepo rsync gcc make rpmdevtools rpm-libs yum-utils rpm-sign"
+    plat.install_build_dependencies_with "yum install --assumeyes"
+    plat.vmpooler_template "redhat-8-arm64"
+  end
+  

--- a/configs/projects/puppet-nightly-release.rb
+++ b/configs/projects/puppet-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '15'
+  proj.release '16'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet-release.rb
+++ b/configs/projects/puppet-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '12'
+  proj.release '13'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/configs/projects/puppet6-nightly-release.rb
+++ b/configs/projects/puppet6-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet6-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '12'
+  proj.release '13'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet6-release.rb
+++ b/configs/projects/puppet6-release.rb
@@ -1,6 +1,6 @@
 project 'puppet6-release' do |proj|
   proj.description 'Release packages for the Puppet 6 repository'
-  proj.release '11'
+  proj.release '12'
   proj.license 'ASL 2.0'
   proj.version '6.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/configs/projects/puppet7-nightly-release.rb
+++ b/configs/projects/puppet7-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet7-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '3'
+  proj.release '4'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'


### PR DESCRIPTION
This PR adds support for Rhel 8 aarch64 on Puppet 6 and Puppet 7.