### PR TITLE
(maint) Add puppet7 release packages

### DIFF
--- a/configs/projects/puppet-release.rb
+++ b/configs/projects/puppet-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '13'
+  proj.release '14'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'
@@ -12,6 +12,7 @@ project 'puppet-release' do |proj|
 
   proj.conflicts 'puppet5-release'
   proj.conflicts 'puppet6-release'
+  proj.conflicts 'puppet7-release'
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'

--- a/configs/projects/puppet5-release.rb
+++ b/configs/projects/puppet5-release.rb
@@ -1,6 +1,6 @@
 project 'puppet5-release' do |proj|
   proj.description 'Release packages for the Puppet5 repository'
-  proj.release '12'
+  proj.release '13'
   proj.license 'ASL 2.0'
   proj.version '5.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'
@@ -12,6 +12,7 @@ project 'puppet5-release' do |proj|
 
   proj.conflicts 'puppet-release'
   proj.conflicts 'puppet6-release'
+  proj.conflicts 'puppet7-release'
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'

--- a/configs/projects/puppet7-release.rb
+++ b/configs/projects/puppet7-release.rb
@@ -1,18 +1,18 @@
-project 'puppet6-release' do |proj|
-  proj.description 'Release packages for the Puppet 6 repository'
-  proj.release '13'
+project 'puppet7-release' do |proj|
+  proj.description 'Release packages for the Puppet 7 repository'
+  proj.release '1'
   proj.license 'ASL 2.0'
-  proj.version '6.0.0'
+  proj.version '7.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'
   proj.homepage 'https://www.puppetlabs.com'
-  proj.target_repo 'puppet6'
+  proj.target_repo 'puppet7'
   proj.noarch
 
-  proj.setting(:target_repo, 'puppet6')
+  proj.setting(:target_repo, 'puppet7')
 
   proj.conflicts 'puppet-release'
   proj.conflicts 'puppet5-release'
-  proj.conflicts 'puppet7-release'
+  proj.conflicts 'puppet6-release'
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'

--- a/files/puppet7.list.txt
+++ b/files/puppet7.list.txt
@@ -1,0 +1,2 @@
+# Puppet 7 __CODENAME__ Repository
+deb http://apt.puppetlabs.com __CODENAME__ puppet7

--- a/files/puppet7.repo.txt
+++ b/files/puppet7.repo.txt
@@ -1,0 +1,7 @@
+[puppet7]
+name=Puppet 7 Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+enabled=1
+gpgcheck=1

--- a/files/puppet7.sles.txt
+++ b/files/puppet7.sles.txt
@@ -1,0 +1,14 @@
+[puppet7]
+name=Puppet 7 Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+enabled=1
+gpgcheck=1
+
+## Update to new key when ready.
+# [puppet7]
+# name=Puppet 7 Repository __OS_NAME__ __OS_VERSION__ - $basearch
+# baseurl=http://yum.puppetlabs.com/puppet7/__OS_NAME__/__OS_VERSION__/$basearch
+# gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+# enabled=1
+# gpgcheck=1


### PR DESCRIPTION
Let me know if I missed anything. Aside from this, there's also the issue of symlinking `puppet7-release` to `puppet-release`, which should be done somewhere in packaging? I'm not sure.