### PR TITLE
(RE-13823) Add SLES component to puppet-tools release

### DIFF
--- a/configs/projects/puppet-tools-release.rb
+++ b/configs/projects/puppet-tools-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-tools-release' do |proj|
   proj.description 'Release packages for the puppet-tools repository'
-  proj.release '5'
+  proj.release '6'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/files/puppet-tools.sles.txt
+++ b/files/puppet-tools.sles.txt
@@ -1,0 +1,14 @@
+[puppet-tools]
+name=Puppet Tools Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://yum.puppet.com/puppet-tools/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-tools-release
+enabled=1
+gpgcheck=1
+
+### Update to new key when ready
+#[puppet-tools]
+#name=Puppet Tools Repository __OS_NAME__ __OS_VERSION__ - $basearch
+#baseurl=http://yum.puppet.com/puppet-tools/__OS_NAME__/__OS_VERSION__/$basearch
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet-tools-release
+#enabled=1
+#gpgcheck=1


### PR DESCRIPTION
Bolt uses the puppet-tools release packages. Need to keep them
up-to-date. This got left behind when we broke out SLES for GPG
key update considerations.