### PR TITLE
(RE-13419) Update nightly release packages with new key

### DIFF
--- a/configs/projects/puppet-nightly-release.rb
+++ b/configs/projects/puppet-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '16'
+  proj.release '17'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet5-nightly-release.rb
+++ b/configs/projects/puppet5-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet5-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '14'
+  proj.release '15'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet6-nightly-release.rb
+++ b/configs/projects/puppet6-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet6-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '13'
+  proj.release '14'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet7-nightly-release.rb
+++ b/configs/projects/puppet7-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet7-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '4'
+  proj.release '5'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/files/puppet-nightly.repo.txt
+++ b/files/puppet-nightly.repo.txt
@@ -2,5 +2,6 @@
 name=Puppet Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
 baseurl=http://nightlies.puppet.com/yum/puppet-nightly/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-nightly-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet-nightly-release
 enabled=1
 gpgcheck=1

--- a/files/puppet-nightly.sles.txt
+++ b/files/puppet-nightly.sles.txt
@@ -1,1 +1,6 @@
-puppet-nightly.repo.txt
+[puppet-nightly]
+name=Puppet Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://nightlies.puppet.com/yum/puppet-nightly/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet-nightly-release
+enabled=1
+gpgcheck=1

--- a/files/puppet5-nightly.repo.txt
+++ b/files/puppet5-nightly.repo.txt
@@ -2,5 +2,6 @@
 name=Puppet 5 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
 baseurl=http://nightlies.puppet.com/yum/puppet5-nightly/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet5-nightly-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet5-nightly-release
 enabled=1
 gpgcheck=1

--- a/files/puppet5-nightly.sles.txt
+++ b/files/puppet5-nightly.sles.txt
@@ -1,1 +1,6 @@
-puppet5-nightly.repo.txt
+[puppet5-nightly]
+name=Puppet 5 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://nightlies.puppet.com/yum/puppet5-nightly/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet5-nightly-release
+enabled=1
+gpgcheck=1

--- a/files/puppet6-nightly.repo.txt
+++ b/files/puppet6-nightly.repo.txt
@@ -2,5 +2,6 @@
 name=Puppet 6 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
 baseurl=http://nightlies.puppet.com/yum/puppet6-nightly/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet6-nightly-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet6-nightly-release
 enabled=1
 gpgcheck=1

--- a/files/puppet6-nightly.sles.txt
+++ b/files/puppet6-nightly.sles.txt
@@ -1,1 +1,6 @@
-puppet6-nightly.repo.txt
+[puppet6-nightly]
+name=Puppet 6 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://nightlies.puppet.com/yum/puppet6-nightly/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet6-nightly-release
+enabled=1
+gpgcheck=1

--- a/files/puppet7-nightly.repo.txt
+++ b/files/puppet7-nightly.repo.txt
@@ -2,5 +2,6 @@
 name=Puppet 7 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
 baseurl=http://nightlies.puppet.com/yum/puppet7-nightly/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-nightly-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-nightly-release
 enabled=1
 gpgcheck=1

--- a/files/puppet7-nightly.sles.txt
+++ b/files/puppet7-nightly.sles.txt
@@ -1,1 +1,6 @@
-puppet7-nightly.repo.txt
+[puppet7-nightly]
+name=Puppet 7 Nightly Repository __OS_NAME__ __OS_VERSION__ - $basearch
+baseurl=http://nightlies.puppet.com/yum/puppet7-nightly/__OS_NAME__/__OS_VERSION__/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-nightly-release
+enabled=1
+gpgcheck=1


### PR DESCRIPTION
I neglected the nightly release packages when I updated the release
packages with the new key. This commit fixes that problem.

While puppet5 may be EOL, I'm including it for the sake of consistency
and paranoia.