### PR TITLE
(CPR-762) Add 'replaces' for older puppet versions

### DIFF
--- a/configs/projects/puppet-nightly-release.rb
+++ b/configs/projects/puppet-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-nightly-release' do |proj|
-  proj.description 'Release packages for the Puppet repository'
-  proj.release '22'
+  proj.description 'Release packages for the Puppet nightly repository'
+  proj.release '23'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'
@@ -9,7 +9,11 @@ project 'puppet-nightly-release' do |proj|
   proj.noarch
 
   proj.conflicts 'puppet5-nightly-release'
+  proj.replaces 'puppet5-nightly-release'
+
   proj.conflicts 'puppet6-nightly-release'
+  proj.replaces 'puppet6-nightly-release'
+
   proj.conflicts 'puppet7-nightly-release'
 
   proj.setting(:target_repo, 'puppet-nightly')

--- a/configs/projects/puppet-release.rb
+++ b/configs/projects/puppet-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '19'
+  proj.release '20'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'
@@ -11,7 +11,11 @@ project 'puppet-release' do |proj|
   proj.setting(:target_repo, 'puppet')
 
   proj.conflicts 'puppet5-release'
+  proj.replaces 'puppet5-release'
+
   proj.conflicts 'puppet6-release'
+  proj.replaces 'puppet6-release'
+
   proj.conflicts 'puppet7-release'
 
   proj.component 'gpg_key'

--- a/configs/projects/puppet7-nightly-release.rb
+++ b/configs/projects/puppet7-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet7-nightly-release' do |proj|
-  proj.description 'Release packages for the Puppet repository'
-  proj.release '10'
+  proj.description 'Release packages for the Puppet7 nightly repository'
+  proj.release '11'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'
@@ -9,8 +9,12 @@ project 'puppet7-nightly-release' do |proj|
   proj.noarch
 
   proj.conflicts 'puppet-nightly-release'
+
   proj.conflicts 'puppet5-nightly-release'
+  proj.replaces 'puppet5-nightly-release'
+
   proj.conflicts 'puppet6-nightly-release'
+  proj.replaces 'puppet6-nightly-release'
 
   proj.setting(:target_repo, 'puppet7-nightly')
 

--- a/configs/projects/puppet7-release.rb
+++ b/configs/projects/puppet7-release.rb
@@ -1,6 +1,6 @@
 project 'puppet7-release' do |proj|
   proj.description 'Release packages for the Puppet 7 repository'
-  proj.release '6'
+  proj.release '7'
   proj.license 'ASL 2.0'
   proj.version '7.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'
@@ -11,8 +11,12 @@ project 'puppet7-release' do |proj|
   proj.setting(:target_repo, 'puppet7')
 
   proj.conflicts 'puppet-release'
+
   proj.conflicts 'puppet5-release'
+  proj.replaces 'puppet5-release'
+
   proj.conflicts 'puppet6-release'
+  proj.replaces 'puppet6-release'
 
   proj.component 'gpg_key'
   proj.component 'repo_definition'


### PR DESCRIPTION
Left the 'floating' puppet version to only conflict with the puppet7-release.
Automatic replacement would cause issues durint 'floating' transition from one puppet
version to the next.