### PR TITLE
Update vanagon_sign_and_ship

### DIFF
--- a/ci/stage_and_ship
+++ b/ci/stage_and_ship
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source /usr/local/rvm/scripts/rvm
-rvm use 2.5.1
+rvm use 2.5.9
 
 set -ex
 

--- a/ci/vanagon_build
+++ b/ci/vanagon_build
@@ -3,7 +3,7 @@
 # Builds all platforms for a vanagon project
 
 source /usr/local/rvm/scripts/rvm
-rvm use 2.5.1
+rvm use 2.5.9
 
 set -x
 

--- a/ci/vanagon_sign_and_ship
+++ b/ci/vanagon_sign_and_ship
@@ -3,7 +3,7 @@
 # Signs and ships artifacts
 
 source /usr/local/rvm/scripts/rvm
-rvm use 2.5.1
+rvm use 2.5.9
 
 set -x
 


### PR DESCRIPTION
DIO-2951 use refreshed ruby versions
the minimum patch level is 2.5.9