### PR TITLE
Add Ubuntu 22.04 support

### DIFF
--- a/configs/platforms/ubuntu-22.04-amd64.rb
+++ b/configs/platforms/ubuntu-22.04-amd64.rb
@@ -1,0 +1,3 @@
+platform "ubuntu-22.04-amd64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/projects/puppet-nightly-release.rb
+++ b/configs/projects/puppet-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet nightly repository'
-  proj.release '24'
+  proj.release '25'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet-release.rb
+++ b/configs/projects/puppet-release.rb
@@ -1,6 +1,6 @@
 project 'puppet-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '21'
+  proj.release '22'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/configs/projects/puppet6-nightly-release.rb
+++ b/configs/projects/puppet6-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet6-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet repository'
-  proj.release '20'
+  proj.release '21'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet6-release.rb
+++ b/configs/projects/puppet6-release.rb
@@ -1,6 +1,6 @@
 project 'puppet6-release' do |proj|
   proj.description 'Release packages for the Puppet 6 repository'
-  proj.release '19'
+  proj.release '20'
   proj.license 'ASL 2.0'
   proj.version '6.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'

--- a/configs/projects/puppet7-nightly-release.rb
+++ b/configs/projects/puppet7-nightly-release.rb
@@ -1,6 +1,6 @@
 project 'puppet7-nightly-release' do |proj|
   proj.description 'Release packages for the Puppet7 nightly repository'
-  proj.release '12'
+  proj.release '13'
   proj.license 'ASL 2.0'
   proj.version '1.0.0'
   proj.vendor 'Puppet Labs <info@puppetlabs.com>'

--- a/configs/projects/puppet7-release.rb
+++ b/configs/projects/puppet7-release.rb
@@ -1,6 +1,6 @@
 project 'puppet7-release' do |proj|
   proj.description 'Release packages for the Puppet 7 repository'
-  proj.release '8'
+  proj.release '9'
   proj.license 'ASL 2.0'
   proj.version '7.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'


### PR DESCRIPTION
I've been installing the `focal` release for my testing and would like to see some support. At the very least, with the `nightlies` release.