### PR TITLE
(CPR-867) Increment the release version for puppet6 and rebuild

### DIFF
--- a/configs/projects/puppet6-release.rb
+++ b/configs/projects/puppet6-release.rb
@@ -1,6 +1,6 @@
 project 'puppet6-release' do |proj|
   proj.description 'Release packages for the Puppet 6 repository'
-  proj.release '22'
+  proj.release '23'
   proj.license 'ASL 2.0'
   proj.version '6.0.0'
   proj.vendor 'Puppet, Inc. <release@puppet.com>'


### PR DESCRIPTION
puppet6-release-6.0.0-22.el8.noarch.rpm didn't make it correctly through
CI, re-release with version incremented.