### PR TITLE
(maint) Workaround https://issues.jenkins.io/browse/JENKINS-64000

### DIFF
--- a/ci/ci-build
+++ b/ci/ci-build
@@ -6,7 +6,7 @@ rvm use 2.7.5
 set -ex
 
 # Workaround for https://issues.jenkins.io/browse/JENKINS-64000
-git fetch --tags
+# git fetch --tags
 
 bundle config set --local path .
 bundle install

--- a/ci/ci-build
+++ b/ci/ci-build
@@ -5,6 +5,9 @@ rvm use 2.7.5
 
 set -ex
 
+# Workaround for https://issues.jenkins.io/browse/JENKINS-64000
+git fetch --tags
+
 bundle config set --local path .
 bundle install
 bundle exec rake clean build sign ship --trace


### PR DESCRIPTION
packaging requires that we have tags fetched in order to do a `git
describe`. Jenkins explicitly excludes tags during clone.

Add a build-step to fetch tags.