### PR TITLE
(maint) help Jenkins with timestamps

### DIFF
--- a/ci/ci-build
+++ b/ci/ci-build
@@ -3,6 +3,7 @@
 source /usr/local/rvm/scripts/rvm
 rvm use 2.7.5
 
+PS4='+ [\d \t] + '
 set -ex
 
 bundle config set --local path .


### PR DESCRIPTION
Jenkins Pipelines' console timestamps aren't as good as classic
Jenkins. Help out by making the build-step script take up some of that
responsibility.

Still not perfect, but much better than nothing.