### PR TITLE
(PA-4902) Add ubuntu puppet8 nightly release packages

### DIFF
--- a/source/projects/puppet8-nightly-release.json
+++ b/source/projects/puppet8-nightly-release.json
@@ -2,7 +2,7 @@
   "project": "puppet8-nightly-release",
   "description": "Release packages for the Puppet 8 nightly repository",
   "version": "1.0.0",
-  "release": "1",
+  "release": "2",
 
   "license": "ASL 2.0",
   "vendor": "Puppet, Inc. <release@puppet.com>",
@@ -11,7 +11,10 @@
 
   "debs": [
     "buster",
-    "bullseye"
+    "bullseye",
+    "bionic",
+    "focal",
+    "jammy"
   ],
 
   "rpms": [


### PR DESCRIPTION
I mistakenly did not add any of the ubuntu platforms to puppet8-nightly-release.json. This commit adds Ubuntu 18.04 (bionic), Ubuntu 20.04 (focal), and Ubuntu 22.04 (jammy) to puppet8-nightly-release.json so there will be puppet8-nightly-release packages generated for those platforms.