### PR TITLE
Rename Amazon 7 to 2

### DIFF
--- a/source/projects/puppet-nightly-release.json
+++ b/source/projects/puppet-nightly-release.json
@@ -25,7 +25,7 @@
     "fedora-36",
     "fedora-40",
     "amazon-2023",
-    "amazon-7"
+    "amazon-2"
   ],
 
   "sles": [

--- a/source/projects/puppet-release.json
+++ b/source/projects/puppet-release.json
@@ -25,7 +25,7 @@
     "fedora-36",
     "fedora-40",
     "amazon-2023",
-    "amazon-7"
+    "amazon-2"
   ],
 
   "sles": [

--- a/source/projects/puppet-tools-release.json
+++ b/source/projects/puppet-tools-release.json
@@ -25,7 +25,7 @@
     "fedora-36",
     "fedora-40",
     "amazon-2023",
-    "amazon-7"
+    "amazon-2"
   ],
 
   "sles": [

--- a/source/projects/puppet7-nightly-release.json
+++ b/source/projects/puppet7-nightly-release.json
@@ -25,7 +25,7 @@
     "fedora-36",
     "fedora-40",
     "amazon-2023",
-    "amazon-7"
+    "amazon-2"
   ],
 
   "sles": [

--- a/source/projects/puppet7-release.json
+++ b/source/projects/puppet7-release.json
@@ -25,7 +25,7 @@
     "fedora-36",
     "fedora-40",
     "amazon-2023",
-    "amazon-7"
+    "amazon-2"
   ],
 
   "sles": [

--- a/source/projects/puppet8-nightly-release.json
+++ b/source/projects/puppet8-nightly-release.json
@@ -25,7 +25,7 @@
     "fedora-36",
     "fedora-40",
     "amazon-2023",
-    "amazon-7"
+    "amazon-2"
   ],
 
   "sles": [

--- a/source/projects/puppet8-release.json
+++ b/source/projects/puppet8-release.json
@@ -25,7 +25,7 @@
     "fedora-36",
     "fedora-40",
     "amazon-2023",
-    "amazon-7"
+    "amazon-2"
   ],
 
   "sles": [


### PR DESCRIPTION
Amazon 7 is an implementation detail, the actual OS is named Amazon 2

~Blocked on release of packaging gem with this change https://github.com/puppetlabs/packaging/pull/1259~