### PR TITLE
RE-16360: Don't install preferences file with puppet-tools-release

### DIFF
--- a/ci/create-packages
+++ b/ci/create-packages
@@ -175,7 +175,7 @@ function install_deb_list_file {
   sed -e "s/__CODENAME__/$os_name/g" "$list_file_source" > "$list_file_build"
 }
 
-## See RE-16301
+## See RE-16301 & RE-16379
 function install_deb_pref_file {
   pref_file_source="$source_directory/$template_source_directory/puppet-release.pref.template"
   pref_file_build="$build_directory/etc/apt/preferences.d/puppet-release.pref"
@@ -189,6 +189,11 @@ function install_deb_pref_file {
 # can later package.
 function create_build_directory {
   package_type=$1
+  want_pref_file=true
+
+  if [[ $project_name == puppet-tools-release ]]; then
+    want_pref_file=false
+  fi
 
   case $project_name in
     puppet*-nightly*)
@@ -220,7 +225,9 @@ function create_build_directory {
       build_directory="$build_base_directory/$os_name/$project_name"
       install_deb_key_files
       install_deb_list_file
-      install_deb_pref_file
+      if [[ $want_pref_file == true ]]; then
+        install_deb_pref_file
+      fi
       ;;
     sles)
       build_directory="$build_base_directory/$os_name/$os_version/$project_name"


### PR DESCRIPTION
Tested (with additional testing for puppet7 -> puppet8 upgrade and puppet -> puppet8 upgrade) all successful.

```
root@unmixed-ballot:~# dpkg  -i puppet7-release_7.0.0-20noble_all.deb
Selecting previously unselected package puppet7-release.
(Reading database ... 83309 files and directories currently installed.)
Preparing to unpack puppet7-release_7.0.0-20noble_all.deb ...
Unpacking puppet7-release (7.0.0-20noble) ...
Setting up puppet7-release (7.0.0-20noble) ...
root@unmixed-ballot:~# dpkg  -i puppet-tools-release_1.0.0-17noble_all.deb
Selecting previously unselected package puppet-tools-release.
(Reading database ... 83314 files and directories currently installed.)
Preparing to unpack puppet-tools-release_1.0.0-17noble_all.deb ...
Unpacking puppet-tools-release (1.0.0-17noble) ...
Setting up puppet-tools-release (1.0.0-17noble) ...
root@unmixed-ballot:~# dpkg  -i puppet8-release_1.0.0-9noble_all.deb
Selecting previously unselected package puppet8-release.
dpkg: considering removing puppet7-release in favour of puppet8-release ...
dpkg: yes, will remove puppet7-release in favour of puppet8-release
(Reading database ... 83318 files and directories currently installed.)
Preparing to unpack puppet8-release_1.0.0-9noble_all.deb ...
Unpacking puppet8-release (1.0.0-9noble) ...
Removing puppet7-release (7.0.0-20noble), to allow configuration of puppet8-release (1.0.0-9noble) ...
Setting up puppet8-release (1.0.0-9noble) ...
```