### PR TITLE
use apt keyring instead of trusted.d

### DIFF
--- a/ci/create-packages
+++ b/ci/create-packages
@@ -133,7 +133,7 @@ function fpm_log_format {
 function install_deb_key_files {
   project_target_repo=$(jq --raw-output .target_repo "$project_json")
   install -D "$source_directory/keyring.gpg" \
-      "$build_directory/etc/apt/trusted.gpg.d/$project_target_repo-keyring.gpg"
+      "$build_directory/etc/apt/keyrings/puppetlabs-keyring.gpg"
 }
 
 function install_rpm_key_files {

--- a/source/apt.puppet.com/puppet-release.list.template
+++ b/source/apt.puppet.com/puppet-release.list.template
@@ -1,2 +1,2 @@
 # Puppet __CODENAME__ Repository
-deb http://apt.puppet.com __CODENAME__ puppet
+deb [signed-by=/etc/apt/keyrings/puppetlabs-keyring.gpg] http://apt.puppet.com __CODENAME__ puppet

--- a/source/apt.puppet.com/puppet-tools-release.list.template
+++ b/source/apt.puppet.com/puppet-tools-release.list.template
@@ -1,2 +1,2 @@
 # Puppet Tools __CODENAME__ Repository
-deb http://apt.puppet.com __CODENAME__ puppet-tools
+deb [signed-by=/etc/apt/keyrings/puppetlabs-keyring.gpg] http://apt.puppet.com __CODENAME__ puppet-tools

--- a/source/apt.puppet.com/puppet7-release.list.template
+++ b/source/apt.puppet.com/puppet7-release.list.template
@@ -1,2 +1,2 @@
 # Puppet 7 __CODENAME__ Repository
-deb http://apt.puppet.com __CODENAME__ puppet7
+deb [signed-by=/etc/apt/keyrings/puppetlabs-keyring.gpg] http://apt.puppet.com __CODENAME__ puppet7

--- a/source/apt.puppet.com/puppet8-release.list.template
+++ b/source/apt.puppet.com/puppet8-release.list.template
@@ -1,2 +1,2 @@
 # Puppet 8 __CODENAME__ Repository
-deb http://apt.puppet.com __CODENAME__ puppet8
+deb [signed-by=/etc/apt/keyrings/puppetlabs-keyring.gpg] http://apt.puppet.com __CODENAME__ puppet8

--- a/source/nightlies.puppet.com/puppet-nightly-release.list.template
+++ b/source/nightlies.puppet.com/puppet-nightly-release.list.template
@@ -1,2 +1,2 @@
 # Puppet Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly
+deb [signed-by=/etc/apt/keyrings/puppetlabs-keyring.gpg] http://nightlies.puppet.com/apt __CODENAME__ puppet-nightly

--- a/source/nightlies.puppet.com/puppet7-nightly-release.list.template
+++ b/source/nightlies.puppet.com/puppet7-nightly-release.list.template
@@ -1,2 +1,2 @@
 # Puppet 7 Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet7-nightly
+deb [signed-by=/etc/apt/keyrings/puppetlabs-keyring.gpg] http://nightlies.puppet.com/apt __CODENAME__ puppet7-nightly

--- a/source/nightlies.puppet.com/puppet8-nightly-release.list.template
+++ b/source/nightlies.puppet.com/puppet8-nightly-release.list.template
@@ -1,2 +1,2 @@
 # Puppet 8 Nightly __CODENAME__ Repository
-deb http://nightlies.puppet.com/apt __CODENAME__ puppet8-nightly
+deb [signed-by=/etc/apt/keyrings/puppetlabs-keyring.gpg] http://nightlies.puppet.com/apt __CODENAME__ puppet8-nightly


### PR DESCRIPTION
In this PR, I'm trying to follow the recommendations from https://wiki.debian.org/DebianRepository/UseThirdParty to move away from trusted.d and use signed-by option with keyrings.

This should solve some error encountered when using puppetlabs-puppet module since the merge of https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/681 (eg. https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/681#issuecomment-2204502810) 

I was still not sure if in the case of puppetlabs-release we should rather put the keyring in `/etc/apt/keyrings` or `/usr/share/keyrings`, feel free to correct me if needed.