### PR TITLE
http to https

### DIFF
--- a/source/yum.puppet.com/puppet-release.repo.template
+++ b/source/yum.puppet.com/puppet-release.repo.template
@@ -1,6 +1,6 @@
 [puppet]
 name=Puppet Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://yum.puppet.com/puppet/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.puppet.com/puppet/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet-release
 enabled=1
 gpgcheck=1

--- a/source/yum.puppet.com/puppet8-release.repo.template
+++ b/source/yum.puppet.com/puppet8-release.repo.template
@@ -1,6 +1,6 @@
 [puppet8]
 name=Puppet 8 Repository __OS_NAME__ __OS_VERSION__ - $basearch
-baseurl=http://yum.puppet.com/puppet8/__OS_NAME__/__OS_VERSION__/$basearch
+baseurl=https://yum.puppet.com/puppet8/__OS_NAME__/__OS_VERSION__/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet8-release
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
Change the base url from rpm repo pupet8 from http to https to comply with companies that do not allow access to sources on port 80 on the internet.